### PR TITLE
[Chore, Fix] Download UI 순서 변경, Rainbow Star와 UI 연동 버그 수정

### DIFF
--- a/Assets/06_SDW_Folder/Scenes/SDW_LobbyScene.unity
+++ b/Assets/06_SDW_Folder/Scenes/SDW_LobbyScene.unity
@@ -14430,6 +14430,67 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1322982542}
   m_CullTransparentMesh: 1
+--- !u!1001 &1330978176
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1838285111673133106, guid: deebb08dc143a3b4ab9c2e1a7ac24287, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1838285111673133106, guid: deebb08dc143a3b4ab9c2e1a7ac24287, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1838285111673133106, guid: deebb08dc143a3b4ab9c2e1a7ac24287, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1838285111673133106, guid: deebb08dc143a3b4ab9c2e1a7ac24287, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1838285111673133106, guid: deebb08dc143a3b4ab9c2e1a7ac24287, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1838285111673133106, guid: deebb08dc143a3b4ab9c2e1a7ac24287, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1838285111673133106, guid: deebb08dc143a3b4ab9c2e1a7ac24287, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1838285111673133106, guid: deebb08dc143a3b4ab9c2e1a7ac24287, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1838285111673133106, guid: deebb08dc143a3b4ab9c2e1a7ac24287, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1838285111673133106, guid: deebb08dc143a3b4ab9c2e1a7ac24287, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3256955993052400061, guid: deebb08dc143a3b4ab9c2e1a7ac24287, type: 3}
+      propertyPath: m_Name
+      value: TestGameManager
+      objectReference: {fileID: 0}
+    - target: {fileID: 3256955993052400061, guid: deebb08dc143a3b4ab9c2e1a7ac24287, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: deebb08dc143a3b4ab9c2e1a7ac24287, type: 3}
 --- !u!1 &1342395840
 GameObject:
   m_ObjectHideFlags: 0
@@ -17439,7 +17500,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &1556829533
 RectTransform:
   m_ObjectHideFlags: 0
@@ -17875,6 +17936,67 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1642148637
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 270.0596
+      objectReference: {fileID: 0}
+    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1271.8857
+      objectReference: {fileID: 0}
+    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -0.6816705
+      objectReference: {fileID: 0}
+    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6277260461048291607, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
+      propertyPath: m_Name
+      value: TestUIOpener
+      objectReference: {fileID: 0}
+    - target: {fileID: 6277260461048291607, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
 --- !u!1 &1652618978
 GameObject:
   m_ObjectHideFlags: 0
@@ -19703,6 +19825,8 @@ MonoBehaviour:
   _gachaButton: {fileID: 33122251}
   _userIcon: {fileID: 1767847817}
   _nicknameText: {fileID: 958288097}
+  _cashStarText: {fileID: 420350632}
+  _rainbowStarText: {fileID: 167634707}
 --- !u!114 &1846366985
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -20894,139 +21018,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &1924975854
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1924975860}
-  - component: {fileID: 1924975859}
-  - component: {fileID: 1924975858}
-  - component: {fileID: 1924975857}
-  - component: {fileID: 1924975856}
-  - component: {fileID: 1924975855}
-  - component: {fileID: 1924975861}
-  - component: {fileID: 1924975862}
-  m_Layer: 0
-  m_Name: GameManager
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1924975855
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1924975854}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fef93ec1af8b5ab4784d9453e5185478, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  dailyQuests:
-  - {fileID: 11400000, guid: 3187b59c549b7884e935f513a641ecad, type: 2}
-  - {fileID: 11400000, guid: 64eb3dee0b6864d41b34002f1d2722e2, type: 2}
-  - {fileID: 11400000, guid: 0886ee9ff4efbab4ab197c78819beb7f, type: 2}
-  - {fileID: 11400000, guid: 1924e75ff074f014497c44dd006f3c97, type: 2}
-  - {fileID: 11400000, guid: 409e853d965fab74aab4361d7c33cccd, type: 2}
-  - {fileID: 11400000, guid: 9b0206f3d9ca7bf42b3ed0217b7ab8ed, type: 2}
-  - {fileID: 11400000, guid: 9916a806d30a06c48a483207599aa6c1, type: 2}
-  currentQuestGoal: 3
---- !u!114 &1924975856
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1924975854}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ebf1b3a6ecdd1c1419ebc433f1d141ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1924975857
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1924975854}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e0ba0ec97a8f44abb19355e502ce7aac, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1924975858
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1924975854}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 52a319f209064a69a2018c8cf086735e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _buyAdRemover: 0
-  _stageName: 
---- !u!114 &1924975859
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1924975854}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eb51d63d7c0e43468b1c365d65419950, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!4 &1924975860
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1924975854}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1924975861
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1924975854}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d5ea38764025481085188a30d710b180, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!114 &1924975862
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1924975854}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5af8f00052794aa083d8862394a4c308, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1926523514
 GameObject:
   m_ObjectHideFlags: 0
@@ -22702,63 +22693,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2132054132}
   m_CullTransparentMesh: 1
---- !u!1001 &2816122614033417098
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 270.0596
-      objectReference: {fileID: 0}
-    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1271.8857
-      objectReference: {fileID: 0}
-    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -0.6816705
-      objectReference: {fileID: 0}
-    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 536844536917423732, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6277260461048291607, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
-      propertyPath: m_Name
-      value: TestUIOpener
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: d217fedec1d951f44af4d3abdc966b96, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -22771,5 +22705,5 @@ SceneRoots:
   - {fileID: 998998303}
   - {fileID: 1147204079}
   - {fileID: 1638836439}
-  - {fileID: 1924975860}
-  - {fileID: 2816122614033417098}
+  - {fileID: 1330978176}
+  - {fileID: 1642148637}

--- a/Assets/06_SDW_Folder/Scripts/Manager/FirebaseManager.cs
+++ b/Assets/06_SDW_Folder/Scripts/Manager/FirebaseManager.cs
@@ -59,7 +59,8 @@ namespace SDW
                     _auth = FirebaseAuth.DefaultInstance;
                     _db = FirebaseDatabase.DefaultInstance.RootReference;
 
-                    _ui.OpenPanel(UIName.SignInUI);
+                    _ui.OpenPanel(UIName.DownloadUI);
+                    OnCheckUpdate?.Invoke();
 
                     if (PlayerPrefs.GetInt("SignedUp", 0) == 0)
                         OnSignInSetButtonType?.Invoke(ButtonType.SignUpButton);
@@ -363,8 +364,7 @@ namespace SDW
         /// </summary>
         private void OnSignInComplete()
         {
-            _ui.OpenPanel(UIName.DownloadUI);
-            OnCheckUpdate?.Invoke();
+            GameManager.Instance.Scene.LoadSceneAsync(SceneName.SDW_LobbyScene);
         }
 
         public void SetNickname(string nickname)

--- a/Assets/06_SDW_Folder/Scripts/Manager/GameManager.cs
+++ b/Assets/06_SDW_Folder/Scripts/Manager/GameManager.cs
@@ -38,8 +38,8 @@ namespace SDW
         private bool _lastBoss;
         public bool LastBoss => _lastBoss;
 
-        private int _starCandy;
-        public int StarCandy => _starCandy = 999999;
+        private int rainbowStarCandy = 999999;
+        public int RainbowStarCandy => rainbowStarCandy;
 
         private int _gachaCount;
         public int GachaCount => _gachaCount;
@@ -88,7 +88,7 @@ namespace SDW
 
         public void SetStageBoss(bool isBoss) => _lastBoss = isBoss;
 
-        public void SubtractStarCandy(int number) => _starCandy -= number;
+        public void SetRainbowStarCandy(int number) => rainbowStarCandy = number;
 
         public void AddGachaCount(int number) => _gachaCount += number;
     }

--- a/Assets/06_SDW_Folder/Scripts/Manager/UIManager.cs
+++ b/Assets/06_SDW_Folder/Scripts/Manager/UIManager.cs
@@ -234,6 +234,7 @@ namespace SDW
         private void ConnectDownloadUI(UIName uiName)
         {
             var downloadUI = _uiDic[uiName] as DownloadUI;
+            downloadUI.OnUIOpenRequested += OpenPanel;
             downloadUI.OnUICloseRequested += ClosePanel;
 
             if (_firebase != null)
@@ -416,6 +417,7 @@ namespace SDW
         private void DisconnectDownloadUI(UIName uiName)
         {
             var downloadUI = _uiDic[uiName] as DownloadUI;
+            downloadUI.OnUIOpenRequested -= OpenPanel;
             downloadUI.OnUICloseRequested -= ClosePanel;
 
             if (_firebase != null)

--- a/Assets/06_SDW_Folder/Scripts/UI/LobbyScene/MainLobbyUI.cs
+++ b/Assets/06_SDW_Folder/Scripts/UI/LobbyScene/MainLobbyUI.cs
@@ -1,4 +1,5 @@
 using System;
+using KSH;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -12,8 +13,11 @@ namespace SDW
         [SerializeField] private Button _userInfoButton;
         [SerializeField] private Button _dailyQuestButton;
         [SerializeField] private Button _gachaButton;
+
         [SerializeField] private Image _userIcon;
         [SerializeField] private TextMeshProUGUI _nicknameText;
+        [SerializeField] private TextMeshProUGUI _cashStarText;
+        [SerializeField] private TextMeshProUGUI _rainbowStarText;
 
         public Action<UIName> OnUIOpenRequested;
         public Action<UIName> OnUICloseRequested;
@@ -32,6 +36,9 @@ namespace SDW
             _userInfoButton.onClick.AddListener(UserInfoButtonClicked);
             _dailyQuestButton.onClick.AddListener(DailyQuestButtonClicked);
             _gachaButton.onClick.AddListener(GachaButtonClicked);
+
+            UpdateRainbowStar(GameManager.Instance.RainbowStarCandy);
+            RewardChangeManager.Instance.OnStarCandyChange += UpdateRainbowStar;
         }
 
         private void OnDisable()
@@ -73,5 +80,10 @@ namespace SDW
         public void SetIcon(Sprite sprite) => _userIcon.sprite = sprite;
 
         #endregion
+
+        public void UpdateRainbowStar(int numOfStars)
+        {
+            _rainbowStarText.text = numOfStars.ToString();
+        }
     }
 }

--- a/Assets/06_SDW_Folder/Scripts/UI/SignInScene/DownloadUI.cs
+++ b/Assets/06_SDW_Folder/Scripts/UI/SignInScene/DownloadUI.cs
@@ -25,6 +25,7 @@ namespace SDW
         private long _patchSize;
         private Dictionary<string, long> _patchMap = new Dictionary<string, long>();
 
+        public Action<UIName> OnUIOpenRequested;
         public Action<UIName> OnUICloseRequested;
 
         private void Awake()
@@ -103,8 +104,8 @@ namespace SDW
                 _downloadSlider.value = 1f;
                 yield return new WaitForSeconds(0.5f);
 
+                OnUIOpenRequested?.Invoke(UIName.SignInUI);
                 OnUICloseRequested?.Invoke(UIName.DownloadUI);
-                GameManager.Instance.Scene.LoadSceneAsync(SceneName.SDW_LobbyScene);
             }
         }
 
@@ -200,8 +201,8 @@ namespace SDW
                 yield return new WaitForEndOfFrame();
             }
 
+            OnUIOpenRequested?.Invoke(UIName.SignInUI);
             OnUICloseRequested?.Invoke(UIName.DownloadUI);
-            GameManager.Instance.Scene.LoadSceneAsync(SceneName.SDW_LobbyScene);
         }
 
         #endregion

--- a/Assets/09_KSH_Folder/Scripts/Gacha/GachaMainUI.cs
+++ b/Assets/09_KSH_Folder/Scripts/Gacha/GachaMainUI.cs
@@ -83,7 +83,7 @@ namespace KSH
         private void Initialize()
         {
             RewardChangeManager.Instance.OnStarCandyChange += CandyUpdate;
-            CandyUpdate(GameManager.Instance.StarCandy);
+            CandyUpdate(GameManager.Instance.RainbowStarCandy);
             _backButton.onClick.AddListener(BackButtonClicked);
         }
 

--- a/Assets/09_KSH_Folder/Scripts/Gacha/RewardChangeManager.cs
+++ b/Assets/09_KSH_Folder/Scripts/Gacha/RewardChangeManager.cs
@@ -14,7 +14,7 @@ namespace KSH
 
         private void Start()
         {
-            starCandy = GameManager.Instance.StarCandy;
+            starCandy = GameManager.Instance.RainbowStarCandy;
         }
 
         public int StarCandy
@@ -23,6 +23,7 @@ namespace KSH
             private set
             {
                 starCandy = value;
+                GameManager.Instance.SetRainbowStarCandy(starCandy);
                 OnStarCandyChange?.Invoke(starCandy);
             }
         }


### PR DESCRIPTION
* Download UI 순서 변경
  * 게임 시작 시 Download가 가장 먼저 실행되도록 수정
* Rainbow Star와 UI 연동 버그 수정
  * Main Lobby UI와 Gacha UI에서 Rainbow Star 보유 수량이 동기화가 안되는 버그 수정


---

# 체크리스트
- [x] 코드가 정상적으로 빌드/실행된다
- [x] 기능이 정상 동작한다
- [x] 심각한 버그나 예상치 못한 문제는 없다