### PR TITLE
[Fix] Editor/모바일에서 Addressable 다운로드 완료가 되지 않는 버그 수정

### DIFF
--- a/Assets/06_SDW_Folder/AddressableObject/ImageSpriteMapping_KGW_TestIngameScene.asset
+++ b/Assets/06_SDW_Folder/AddressableObject/ImageSpriteMapping_KGW_TestIngameScene.asset
@@ -13,18 +13,6 @@ MonoBehaviour:
   m_Name: ImageSpriteMapping_KGW_TestIngameScene
   m_EditorClassIdentifier: 
   entries:
-  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Third/MPBar/Outline
-    AddressKey: 0c92d89ca2497324a85c04d355a14743
-    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 27 (3).png
-  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Third/HPBar/Outline
-    AddressKey: 0c92d89ca2497324a85c04d355a14743
-    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 27 (3).png
-  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Third/CharacterImage
-    AddressKey: baefb0215243a804982570185e7eec30
-    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/simpleWhite.jpg
-  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Third
-    AddressKey: cbb100b9b8fc7cf40b52289f13994d4d
-    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 2.png
   - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_First/MPBar/Outline
     AddressKey: 0c92d89ca2497324a85c04d355a14743
     AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 27 (3).png
@@ -47,6 +35,18 @@ MonoBehaviour:
     AddressKey: 57daccc1527ca1d43abc8eea0dd14179
     AssetPath: Assets/06_SDW_Folder/Sprites/PanelBackground.png
   - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Second
+    AddressKey: cbb100b9b8fc7cf40b52289f13994d4d
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 2.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Third/MPBar/Outline
+    AddressKey: 0c92d89ca2497324a85c04d355a14743
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 27 (3).png
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Third/HPBar/Outline
+    AddressKey: 0c92d89ca2497324a85c04d355a14743
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 27 (3).png
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Third/CharacterImage
+    AddressKey: baefb0215243a804982570185e7eec30
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/simpleWhite.jpg
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Third
     AddressKey: cbb100b9b8fc7cf40b52289f13994d4d
     AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 2.png
   - Path: PopupCanvas/ClearStageContainer/MenuBox/Banner
@@ -82,9 +82,270 @@ MonoBehaviour:
   - Path: PopupCanvas/ClearStageContainer/MenuBox/SelectTreasure/Popup_TreasureExplanation
     AddressKey: dbaf53e7bca762e4ca8002e2b3261ca2
     AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Group 16.png
-  - Path: Canvas/DefaultUIContainer/TopUI/FastGameButtonX1
+  - Path: Canvas/DefaultUIContainer/TopUI/FastGameBG
+    AddressKey: 1d7501232a26f3d4ba68eb61c8ac5dcf
+    AssetPath: Assets/00_Imports/12_LSR_Assets/Farm Game UI - Simple 2D UI/Sprites/256x256/panel_2.png
+  - Path: PopupCanvas/ClearStageContainer/MenuBox/SelectTreasure/SelectTreasure3/Button_TreasureExplanation
+    AddressKey: c9aca08061ecc37419462ae563e2036b
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Ellipse 4.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/ScrollRect_FoodItem/Contents/Button
+      (2)
+    AddressKey: 1adee86810193154a8158e4c5f073d78
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Dish-01 1.png
+  - Path: Canvas/DefaultUIContainer/TopUI/Button_Menu
+    AddressKey: ff983db7a066da747bbb73ec74fcd388
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Menu_Button.png
+  - Path: PopupCanvas/NonRemoveADContainer/MenuBox/IsOkaytoGoLobby/SubMenuBox/Button_No
+    AddressKey: f6b30aa533db96c43ade1c8ba5784ceb
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 35.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/ScrollRect_FoodItem/Contents/Button
+      (6)
+    AddressKey: 1adee86810193154a8158e4c5f073d78
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Dish-01 1.png
+  - Path: Canvas/DefaultUIContainer/TopUI/StageInfo_Time_EnemyHP/OutsideBar
+    AddressKey: 1606dc27f903f024887aa6e29dc38181
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 26 (1).png
+  - Path: PopupCanvas/SettingConainer/MenuBox/Slider_BGM/Background
+    AddressKey: 9e9eca082bb6b3242904bf6a870283ac
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 34.png
+  - Path: PopupCanvas/ClearStageContainer/MenuBox/SelectTreasure/SelectTreasure3/Button_TreasureExplanation/Image
+    AddressKey: 781799cc038aec24f9e14c5c4fbd96a0
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Dopboki1-01.png
+  - Path: PopupCanvas/ClearStageContainer/MenuBox/SelectTreasure/SelectTreasure1/Button_TreasureExplanation
+    AddressKey: c9aca08061ecc37419462ae563e2036b
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Ellipse 4.png
+  - Path: PopupCanvas/ClearChapterContainer/MenuBox/Banner
+    AddressKey: 7ec18a2d903eb7a478bae080835c97a1
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/RibbonBanner.png
+  - Path: PopupCanvas/ClearStageContainer/MenuBox/SelectTreasure/SelectTreasure1
+    AddressKey: dbaf53e7bca762e4ca8002e2b3261ca2
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Group 16.png
+  - Path: PopupCanvas/NonRemoveADContainer/MenuBox/Button_Retry
+    AddressKey: f6b30aa533db96c43ade1c8ba5784ceb
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 35.png
+  - Path: PopupCanvas/RemoveAdContainer/MenuBox
+    AddressKey: 0e3d32e53abe9a241a1a3086fa0a4b82
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 33.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_TreasureClosed/Button_TreasureOpened
+    AddressKey: 83f3fdafa399cce4180b249bfa2aabeb
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Group 25.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/ScrollRect_FoodItem/Contents/Button
+      (3)
+    AddressKey: 1adee86810193154a8158e4c5f073d78
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Dish-01 1.png
+  - Path: PopupCanvas/RemoveAdContainer/MenuBox/IsOkaytoGoLobby/SubMenuBox/Button_No
+    AddressKey: f6b30aa533db96c43ade1c8ba5784ceb
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 35.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/ScrollRect_FoodItem/Contents/Button
+      (5)
+    AddressKey: 1adee86810193154a8158e4c5f073d78
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Dish-01 1.png
+  - Path: Canvas/DefaultUIContainer/TopUI/StageInfo_Time_EnemyHP/Time
+    AddressKey: c9aca08061ecc37419462ae563e2036b
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Ellipse 4.png
+  - Path: PopupCanvas/ClearStageContainer/MenuBox/Button_GoOn
+    AddressKey: f6b30aa533db96c43ade1c8ba5784ceb
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 35.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/ScrollRect_FoodItem/Contents/Button
+    AddressKey: 1adee86810193154a8158e4c5f073d78
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Dish-01 1.png
+  - Path: PopupCanvas/DefeatContainer/MenuBox/Button_GoLobby
+    AddressKey: f6b30aa533db96c43ade1c8ba5784ceb
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 35.png
+  - Path: PopupCanvas/SettingConainer/MenuBox
+    AddressKey: 0e3d32e53abe9a241a1a3086fa0a4b82
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 33.png
+  - Path: PopupCanvas/ClearChapterContainer/MenuBox/Reward/Exp
+    AddressKey: dbaf53e7bca762e4ca8002e2b3261ca2
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Group 16.png
+  - Path: PopupCanvas/ClearStageContainer/MenuBox/SelectTreasure/SelectTreasure1/Button_TreasureExplanation/Image
+    AddressKey: 781799cc038aec24f9e14c5c4fbd96a0
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Dopboki1-01.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/ScrollRect_FoodItem/Contents/Button
+      (1)
+    AddressKey: 1adee86810193154a8158e4c5f073d78
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Dish-01 1.png
+  - Path: PopupCanvas/NonRemoveADContainer/MenuBox
+    AddressKey: 0e3d32e53abe9a241a1a3086fa0a4b82
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 33.png
+  - Path: PopupCanvas/SettingConainer/MenuBox/Slider_SFX/Handle Slide Area/Handle
+    AddressKey: 84779bcd61d73e547bdbaba1615dffed
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Ellipse 7.png
+  - Path: PopupCanvas/DefeatContainer/MenuBox/Reward/Exp
+    AddressKey: dbaf53e7bca762e4ca8002e2b3261ca2
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Group 16.png
+  - Path: PopupCanvas/RemoveAdContainer/MenuBox/IsOkaytoGoLobby/SubMenuBox
+    AddressKey: 0e3d32e53abe9a241a1a3086fa0a4b82
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 33.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/ScrollRect_FoodItem/Contents/Button
+      (9)
+    AddressKey: 1adee86810193154a8158e4c5f073d78
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Dish-01 1.png
+  - Path: PopupCanvas/ClearStageContainer/MenuBox/SelectTreasure/Popup_TreasureExplanation/TreasureImgBG
+    AddressKey: dbaf53e7bca762e4ca8002e2b3261ca2
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Group 16.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_TreasureClosed/Button_TreasureOpened/Contents
+    AddressKey: 7e5999eb0e5be954db30dcc109e2fa1d
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 36.png
+  - Path: PopupCanvas/SettingConainer/MenuBox/Slider_SFX/Background
+    AddressKey: 9e9eca082bb6b3242904bf6a870283ac
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 34.png
+  - Path: PopupCanvas/NonRemoveADContainer/MenuBox/Button_Retry/Image
+    AddressKey: 578ecbd68c1b6dc448971ab65eaebbd0
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/ADIcon-01.png
+  - Path: PopupCanvas/RemoveAdContainer/MenuBox/Button_Retry
+    AddressKey: f6b30aa533db96c43ade1c8ba5784ceb
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 35.png
+  - Path: PopupCanvas/DefeatContainer/MenuBox
+    AddressKey: 0e3d32e53abe9a241a1a3086fa0a4b82
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 33.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/ScrollRect_FoodItem/Contents/Button
+      (8)
+    AddressKey: 1adee86810193154a8158e4c5f073d78
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Dish-01 1.png
+  - Path: PopupCanvas/RemoveAdContainer/MenuBox/Banner
+    AddressKey: 7ec18a2d903eb7a478bae080835c97a1
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/RibbonBanner.png
+  - Path: Canvas/DefaultUIContainer/TopUI/StageText
+    AddressKey: 7dce5b391dddf81448e2b4c71f5820cf
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/StageBanner.png
+  - Path: Canvas/DefaultUIContainer/TopUI/StageInfo_Time_EnemyHP/InsideBar_Empty
+    AddressKey: 840052e1f1b87484abf6eb7069bba3be
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 26 (2).png
+  - Path: PopupCanvas/ClearStageContainer/MenuBox
+    AddressKey: 0e3d32e53abe9a241a1a3086fa0a4b82
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 33.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/ScrollRect_FoodItem/Contents/Button
+      (7)
+    AddressKey: 1adee86810193154a8158e4c5f073d78
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Dish-01 1.png
+  - Path: PopupCanvas/ClearChapterContainer/MenuBox
+    AddressKey: 0e3d32e53abe9a241a1a3086fa0a4b82
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 33.png
+  - Path: PopupCanvas/DefeatContainer/MenuBox/Banner
+    AddressKey: 7ec18a2d903eb7a478bae080835c97a1
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/RibbonBanner.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/ScrollRect_FoodItem/Contents/Button
+      (4)
+    AddressKey: 1adee86810193154a8158e4c5f073d78
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Dish-01 1.png
+  - Path: PopupCanvas/ClearStageContainer/MenuBox/SelectTreasure/SelectTreasure2/Button_TreasureExplanation
+    AddressKey: c9aca08061ecc37419462ae563e2036b
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Ellipse 4.png
+  - Path: PopupCanvas/SettingConainer/MenuBox/IsOkaytoGoLobby/SubMenuBox/Button_No
+    AddressKey: f6b30aa533db96c43ade1c8ba5784ceb
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 35.png
+  - Path: PopupCanvas/SettingConainer/MenuBox/Button_GoOn
+    AddressKey: f6b30aa533db96c43ade1c8ba5784ceb
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 35.png
+  - Path: PopupCanvas/ClearStageContainer/MenuBox/SelectTreasure/SelectTreasure3
+    AddressKey: dbaf53e7bca762e4ca8002e2b3261ca2
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Group 16.png
+  - Path: PopupCanvas/SettingConainer/MenuBox/IsOkaytoGoLobby/SubMenuBox
+    AddressKey: 0e3d32e53abe9a241a1a3086fa0a4b82
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 33.png
+  - Path: PopupCanvas/RemoveAdContainer/MenuBox/Button_GoLobby
+    AddressKey: f6b30aa533db96c43ade1c8ba5784ceb
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 35.png
+  - Path: PopupCanvas/SettingConainer/MenuBox/IsOkaytoGoLobby/SubMenuBox/Button_Yes
+    AddressKey: f6b30aa533db96c43ade1c8ba5784ceb
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 35.png
+  - Path: PopupCanvas/NonRemoveADContainer/MenuBox/IsOkaytoGoLobby/SubMenuBox/Button_Yes
+    AddressKey: f6b30aa533db96c43ade1c8ba5784ceb
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 35.png
+  - Path: PopupCanvas/NonRemoveADContainer/MenuBox/Button_GoLobby
+    AddressKey: f6b30aa533db96c43ade1c8ba5784ceb
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 35.png
+  - Path: PopupCanvas/ClearChapterContainer/MenuBox/Reward/GrowthPoint
+    AddressKey: dbaf53e7bca762e4ca8002e2b3261ca2
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Group 16.png
+  - Path: PopupCanvas/ClearChapterContainer/MenuBox/Button_GoLobby
+    AddressKey: f6b30aa533db96c43ade1c8ba5784ceb
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 35.png
+  - Path: PopupCanvas/ClearStageContainer/MenuBox/SelectTreasure/Popup_TreasureExplanation/Button_Close
+    AddressKey: c9aca08061ecc37419462ae563e2036b
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Ellipse 4.png
+  - Path: Canvas/DefaultUIContainer/TopUI/FastGameButtonX2
     AddressKey: 86ab64f450903af4a99a28cb87c2ea8a
     AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 28 (1).png
+  - Path: PopupCanvas/NonRemoveADContainer/MenuBox/IsOkaytoGoLobby/SubMenuBox
+    AddressKey: 0e3d32e53abe9a241a1a3086fa0a4b82
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 33.png
+  - Path: PopupCanvas/SettingConainer/MenuBox/Button_GoLobby
+    AddressKey: f6b30aa533db96c43ade1c8ba5784ceb
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 35.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_First/MPBar/Outline
+    AddressKey: 0c92d89ca2497324a85c04d355a14743
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 27 (3).png
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_First/HPBar/Outline
+    AddressKey: 0c92d89ca2497324a85c04d355a14743
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 27 (3).png
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_First/CharacterImage
+    AddressKey: baefb0215243a804982570185e7eec30
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/simpleWhite.jpg
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_First
+    AddressKey: cbb100b9b8fc7cf40b52289f13994d4d
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 2.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Second/MPBar/Outline
+    AddressKey: 0c92d89ca2497324a85c04d355a14743
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 27 (3).png
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Second/HPBar/Outline
+    AddressKey: 0c92d89ca2497324a85c04d355a14743
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 27 (3).png
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Second/CharacterImage
+    AddressKey: 57daccc1527ca1d43abc8eea0dd14179
+    AssetPath: Assets/06_SDW_Folder/Sprites/PanelBackground.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Second
+    AddressKey: cbb100b9b8fc7cf40b52289f13994d4d
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 2.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Third/MPBar/Outline
+    AddressKey: 0c92d89ca2497324a85c04d355a14743
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 27 (3).png
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Third/HPBar/Outline
+    AddressKey: 0c92d89ca2497324a85c04d355a14743
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 27 (3).png
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Third/CharacterImage
+    AddressKey: baefb0215243a804982570185e7eec30
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/simpleWhite.jpg
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_CharacterCard_Third
+    AddressKey: cbb100b9b8fc7cf40b52289f13994d4d
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 2.png
+  - Path: PopupCanvas/ClearStageContainer/MenuBox/Banner
+    AddressKey: 7ec18a2d903eb7a478bae080835c97a1
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/RibbonBanner.png
+  - Path: PopupCanvas/DefeatContainer/MenuBox/Reward/GrowthPoint
+    AddressKey: dbaf53e7bca762e4ca8002e2b3261ca2
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Group 16.png
+  - Path: Canvas/DefaultUIContainer/BottomUI/Button_TreasureClosed
+    AddressKey: 335f7c7ba8037d54386f17ba306f438f
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Treasure.png
+  - Path: PopupCanvas/ClearStageContainer/MenuBox/SelectTreasure/SelectTreasure2
+    AddressKey: dbaf53e7bca762e4ca8002e2b3261ca2
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Group 16.png
+  - Path: PopupCanvas/RemoveAdContainer/MenuBox/IsOkaytoGoLobby/SubMenuBox/Button_Yes
+    AddressKey: f6b30aa533db96c43ade1c8ba5784ceb
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Rectangle 35.png
+  - Path: PopupCanvas/ClearStageContainer/MenuBox/SelectTreasure/Popup_TreasureExplanation/TreasureExBG
+    AddressKey: dbaf53e7bca762e4ca8002e2b3261ca2
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Group 16.png
+  - Path: PopupCanvas/SettingConainer/MenuBox/Slider_BGM/Handle Slide Area/Handle
+    AddressKey: 84779bcd61d73e547bdbaba1615dffed
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Ellipse 7.png
+  - Path: PopupCanvas/ClearStageContainer/MenuBox/SelectTreasure/SelectTreasure2/Button_TreasureExplanation/Image
+    AddressKey: 781799cc038aec24f9e14c5c4fbd96a0
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Dopboki1-01.png
+  - Path: Canvas/DefaultUIContainer/BackGround
+    AddressKey: d6c402df4c1130145a5368fb8087f29a
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/BG.png
+  - Path: PopupCanvas/NonRemoveADContainer/MenuBox/Banner
+    AddressKey: 7ec18a2d903eb7a478bae080835c97a1
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/RibbonBanner.png
+  - Path: PopupCanvas/ClearStageContainer/MenuBox/SelectTreasure/Popup_TreasureExplanation
+    AddressKey: dbaf53e7bca762e4ca8002e2b3261ca2
+    AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Group 16.png
+  - Path: Canvas/DefaultUIContainer/TopUI/FastGameBG
+    AddressKey: 1d7501232a26f3d4ba68eb61c8ac5dcf
+    AssetPath: Assets/00_Imports/12_LSR_Assets/Farm Game UI - Simple 2D UI/Sprites/256x256/panel_2.png
   - Path: PopupCanvas/ClearStageContainer/MenuBox/SelectTreasure/SelectTreasure3/Button_TreasureExplanation
     AddressKey: c9aca08061ecc37419462ae563e2036b
     AssetPath: Assets/00_Imports/11_LCS_Assets/UI/Ellipse 4.png

--- a/Assets/06_SDW_Folder/AddressableObject/ImageSpriteMapping_SDW_LobbyScene.asset
+++ b/Assets/06_SDW_Folder/AddressableObject/ImageSpriteMapping_SDW_LobbyScene.asset
@@ -145,3 +145,135 @@ MonoBehaviour:
   - Path: '- UI/GatchaCanvas/GatchResultContainer/GatchResultPanel/BGImg'
     AddressKey: 670cd4951ea466c41bb440a6b8cf87fa
     AssetPath: Assets/00_Imports/10_LYH_Assets/UI/Kitchen.png
+  - Path: '- UI/GatchaCanvas/GatchMainContainer/GatchMainPanel/StarCandyContainer/OwnedStarCandyText'
+    AddressKey: e354caf3995476148b31593e9d16161c
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/SugarStar.png
+  - Path: '- UI/LobbySceneCanvas/UserInfoContainer/UserInfoPanel/TopViewPanel/IconImg'
+    AddressKey: d5448dba9da6a1842a72be7b75a3b29a
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/charIcon_BaekWoong.png
+  - Path: '- UI/LobbySceneCanvas/MainLobbyContainer/MainLobbyPanel/BackgroundImage/CharImage'
+    AddressKey: 24249137a07ad9547b984a1771f441eb
+    AssetPath: Assets/00_Imports/10_LYH_Assets/CharImgs/07-25_00001_.png
+  - Path: '- UI/LobbySceneCanvas/UserInfoContainer/ChangeIconContainer/ChangeIconPanel/Scroll
+      View/Viewport/Content/Image'
+    AddressKey: d5448dba9da6a1842a72be7b75a3b29a
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/charIcon_BaekWoong.png
+  - Path: '- UI/LobbySceneCanvas/DailyQuestContainer/DailyQuestPanel/Panel/QuestScrollView/Viewport/Content/Quest2/CheckImg'
+    AddressKey: 2a8f33a9d85786b4287bd92fa9bd534d
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/check.png
+  - Path: '- UI/GatchaCanvas/GatchMainContainer/GatchMainPanel/BGImg'
+    AddressKey: 670cd4951ea466c41bb440a6b8cf87fa
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/Kitchen.png
+  - Path: '- UI/LobbySceneCanvas/MainLobbyContainer/MainLobbyPanel/TopViewContainer/CurrencyPanel/ShiningSugarStarImage'
+    AddressKey: e354caf3995476148b31593e9d16161c
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/SugarStar.png
+  - Path: '- UI/LobbySceneCanvas/UserInfoContainer/ChangeIconContainer/ChangeIconPanel/Scroll
+      View/Viewport/Content/Image (1)'
+    AddressKey: a97a12855bbbf824cb5c99b29c3e6b13
+    AssetPath: Assets/00_Imports/10_LYH_Assets/TempCharacter/BCA_BattleIcon.png
+  - Path: '- UI/LobbySceneCanvas/DailyQuestContainer/DailyQuestPanel/Panel/QuestScrollView/Viewport/Content/Quest5/CheckImg'
+    AddressKey: 2a8f33a9d85786b4287bd92fa9bd534d
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/check.png
+  - Path: '- UI/LobbySceneCanvas/DailyQuestContainer/DailyQuestPanel/Panel/QuestScrollView/Viewport/Content/Quest1/CheckImg'
+    AddressKey: 2a8f33a9d85786b4287bd92fa9bd534d
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/check.png
+  - Path: '- UI/GatchaCanvas/GatchMainContainer/GatchMainPanel/StarCandyContainer/NeedStarCandyTen'
+    AddressKey: e354caf3995476148b31593e9d16161c
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/SugarStar.png
+  - Path: '- UI/LobbySceneCanvas/MainLobbyContainer/MainLobbyPanel/TopViewContainer/CurrencyPanel/SugarStarImage'
+    AddressKey: a32384600a25cef45a135c7ca6c5ee19
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/ShiningSugarStar.png
+  - Path: '- UI/LobbySceneCanvas/UserInfoContainer/ChangeIconContainer/ChangeIconPanel/Scroll
+      View/Viewport/Content/Image (8)'
+    AddressKey: d5448dba9da6a1842a72be7b75a3b29a
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/charIcon_BaekWoong.png
+  - Path: '- UI/LobbySceneCanvas/MainLobbyContainer/MainLobbyPanel/BottomViewContainer/BottomPanel'
+    AddressKey: bb67ece2190820c488cb1138c554dbe5
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/Gradient.png
+  - Path: '- UI/GatchaCanvas/GatchMainContainer/GatchMainPanel/PopupPanelContainer/PannelBackgroundImage'
+    AddressKey: 29ea1f68be149f54e8c0f1d9642633bf
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/charBanner.jpg
+  - Path: '- UI/LobbySceneCanvas/UserInfoContainer/ChangeIconContainer/ChangeIconPanel/Scroll
+      View/Viewport/Content/Image (2)'
+    AddressKey: 68cea2103c29b2a41ad1b9752a8f09a2
+    AssetPath: Assets/00_Imports/10_LYH_Assets/TempCharacter/HSR_BattleIcon.png
+  - Path: '- UI/LobbySceneCanvas/DailyQuestContainer/DailyQuestPanel/Panel/QuestScrollView/Viewport/Content/Quest3/CheckImg'
+    AddressKey: 2a8f33a9d85786b4287bd92fa9bd534d
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/check.png
+  - Path: '- UI/LobbySceneCanvas/UserInfoContainer/ChangeIconContainer/ChangeIconPanel/Scroll
+      View/Viewport/Content/Image (3)'
+    AddressKey: 4a586d247219bbb448e6b2ce172d7dfd
+    AssetPath: Assets/00_Imports/10_LYH_Assets/TempCharacter/SIL_BattleIcon.png
+  - Path: '- UI/LobbySceneCanvas/UserInfoContainer/ChangeIconContainer/ChangeIconPanel/Scroll
+      View/Viewport/Content/Image (6)'
+    AddressKey: d5448dba9da6a1842a72be7b75a3b29a
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/charIcon_BaekWoong.png
+  - Path: '- UI/GatchaCanvas/GatchMainContainer/GatchMainPanel/ButtonCotainer/1PullButton'
+    AddressKey: 50035cd58d3629d428ec6ac99b2134d1
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/1Pull.png
+  - Path: '- UI/GatchaCanvas/GatchMainContainer/GatchMainPanel/StarCandyContainer/NeedStarCandyOne'
+    AddressKey: e354caf3995476148b31593e9d16161c
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/SugarStar.png
+  - Path: '- UI/LobbySceneCanvas/DailyQuestContainer/DailyQuestPanel/BGImg'
+    AddressKey: 670cd4951ea466c41bb440a6b8cf87fa
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/Kitchen.png
+  - Path: '- UI/LobbySceneCanvas/DailyQuestContainer/DailyQuestPanel/Panel/QuestScrollView/Viewport/Content/Quest4/CheckImg'
+    AddressKey: 2a8f33a9d85786b4287bd92fa9bd534d
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/check.png
+  - Path: '- UI/LobbySceneCanvas/MainLobbyContainer/MainLobbyPanel/CharacterPanel/LineImage'
+    AddressKey: baefb0215243a804982570185e7eec30
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/simpleWhite.jpg
+  - Path: '- UI/LobbySceneCanvas/DailyQuestContainer/DailyQuestPanel/Panel/QuestScrollView/Viewport/Content/Quest7/CheckImg'
+    AddressKey: 2a8f33a9d85786b4287bd92fa9bd534d
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/check.png
+  - Path: '- UI/GatchaCanvas/GatchMainContainer/GatchMainPanel/PopupPanelContainer/BannerTitleImg'
+    AddressKey: 841efed9e6590ae4694d23c57b02444f
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/paper.jpg
+  - Path: '- UI/LobbySceneCanvas/DailyQuestContainer/DailyQuestPanel/Panel/GoBackIcon'
+    AddressKey: 9ec1937e58d39964c946ae9dee62a13d
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/GoBackIcon.png
+  - Path: '- UI/LobbySceneCanvas/DailyQuestContainer/DailyQuestPanel/Panel/RewardImg'
+    AddressKey: e354caf3995476148b31593e9d16161c
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/SugarStar.png
+  - Path: '- UI/LobbySceneCanvas/UserInfoContainer/ChangeIconContainer/ChangeIconPanel/Scroll
+      View/Viewport/Content/Image (4)'
+    AddressKey: d5448dba9da6a1842a72be7b75a3b29a
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/charIcon_BaekWoong.png
+  - Path: '- UI/LobbySceneCanvas/MainLobbyContainer/MainLobbyPanel/BackgroundImage/BackgroundImage'
+    AddressKey: 670cd4951ea466c41bb440a6b8cf87fa
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/Kitchen.png
+  - Path: '- UI/GatchaCanvas/GatchResultContainer/GatchResultPanel/GoBackIcon'
+    AddressKey: 9ec1937e58d39964c946ae9dee62a13d
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/GoBackIcon.png
+  - Path: '- UI/GatchaCanvas/GatchMainContainer/GatchMainPanel/ButtonCotainer/10PullsButton'
+    AddressKey: 2f941e94710d8bc478e8c40b17029ddf
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/10Pulls.png
+  - Path: '- UI/LobbySceneCanvas/MainLobbyContainer/MainLobbyPanel/BottomViewContainer/BottomPanel/CharIconImage'
+    AddressKey: d5448dba9da6a1842a72be7b75a3b29a
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/charIcon_BaekWoong.png
+  - Path: '- UI/LobbySceneCanvas/DailyQuestContainer/DailyQuestPanel/Panel/PaperImg'
+    AddressKey: 841efed9e6590ae4694d23c57b02444f
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/paper.jpg
+  - Path: '- UI/LobbySceneCanvas/DailyQuestContainer/DailyQuestPanel/Panel/QuestScrollView/Viewport/Content/Quest6/CheckImg'
+    AddressKey: 2a8f33a9d85786b4287bd92fa9bd534d
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/check.png
+  - Path: '- UI/LobbySceneCanvas/MainLobbyContainer/MainLobbyPanel/BottomViewContainer/BottomPanel/Image'
+    AddressKey: ee31448a767dabe41b47978bee191715
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/settingIcon.png
+  - Path: '- UI/LobbySceneCanvas/DailyQuestContainer/DailyQuestPanel/Panel/PinImg'
+    AddressKey: 2835c2ea1c884874ea9c001e78bf5d34
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/pin.png
+  - Path: '- UI/GatchaCanvas/GatchMainContainer/GatchMainPanel/ButtonCotainer/GoBackIcon'
+    AddressKey: 9ec1937e58d39964c946ae9dee62a13d
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/GoBackIcon.png
+  - Path: '- UI/LobbySceneCanvas/UserInfoContainer/ChangeIconContainer/ChangeIconPanel/Scroll
+      View/Viewport/Content/Image (7)'
+    AddressKey: d5448dba9da6a1842a72be7b75a3b29a
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/charIcon_BaekWoong.png
+  - Path: '- UI/LobbySceneCanvas/UserInfoContainer/ChangeIconContainer/ChangeIconPanel/Scroll
+      View/Viewport/Content/Image (5)'
+    AddressKey: d5448dba9da6a1842a72be7b75a3b29a
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/charIcon_BaekWoong.png
+  - Path: '- UI/GatchaCanvas/GatchResultContainer/GatchResultPanel/BGImg'
+    AddressKey: 670cd4951ea466c41bb440a6b8cf87fa
+    AssetPath: Assets/00_Imports/10_LYH_Assets/UI/Kitchen.png

--- a/Assets/06_SDW_Folder/AddressableObject/ImageSpriteMapping_SDW_SignInScene.asset
+++ b/Assets/06_SDW_Folder/AddressableObject/ImageSpriteMapping_SDW_SignInScene.asset
@@ -28,3 +28,27 @@ MonoBehaviour:
   - Path: '- UI/SignInCanvas/SetNicknameContainer/SetNicknamePanel'
     AddressKey: 57daccc1527ca1d43abc8eea0dd14179
     AssetPath: Assets/06_SDW_Folder/Sprites/PanelBackground.png
+  - Path: '- UI/SignInCanvas/SignInContainer/SignInPanel'
+    AddressKey: 57daccc1527ca1d43abc8eea0dd14179
+    AssetPath: Assets/06_SDW_Folder/Sprites/PanelBackground.png
+  - Path: '- UI/SignInCanvas/DownloadContainer/DownloadPanel'
+    AddressKey: 57daccc1527ca1d43abc8eea0dd14179
+    AssetPath: Assets/06_SDW_Folder/Sprites/PanelBackground.png
+  - Path: '- UI/SignInCanvas/SignInContainer'
+    AddressKey: 9dabe2e845efb504eb745e1ce37cff58
+    AssetPath: Assets/06_SDW_Folder/Sprites/android_neutral_rd_SU@4x.png
+  - Path: '- UI/SignInCanvas/SignInContainer'
+    AddressKey: 8600060538fce3a4aaf99e87c0c7871f
+    AssetPath: Assets/06_SDW_Folder/Sprites/android_neutral_rd_SI@4x.png
+  - Path: '- UI/SignInCanvas/SignInContainer'
+    AddressKey: 38b5fc1248630a14996dee5d1b079485
+    AssetPath: Assets/06_SDW_Folder/Sprites/android_neutral_rd_ctn@4x.png
+  - Path: '- UI/SignInCanvas/SetNicknameContainer/SetNicknamePanel/NicknameInputField'
+    AddressKey: 57daccc1527ca1d43abc8eea0dd14179
+    AssetPath: Assets/06_SDW_Folder/Sprites/PanelBackground.png
+  - Path: '- UI/SignInCanvas/SignInContainer/SignInPanel/SignInButton'
+    AddressKey: 9dabe2e845efb504eb745e1ce37cff58
+    AssetPath: Assets/06_SDW_Folder/Sprites/android_neutral_rd_SU@4x.png
+  - Path: '- UI/SignInCanvas/SetNicknameContainer/SetNicknamePanel'
+    AddressKey: 57daccc1527ca1d43abc8eea0dd14179
+    AssetPath: Assets/06_SDW_Folder/Sprites/PanelBackground.png

--- a/Assets/06_SDW_Folder/Scenes/SDW_SignInScene.unity
+++ b/Assets/06_SDW_Folder/Scenes/SDW_SignInScene.unity
@@ -122,46 +122,6 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
---- !u!21 &117937862
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 500, g: 400, b: 80, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1 &409360276
 GameObject:
   m_ObjectHideFlags: 0
@@ -174,6 +134,7 @@ GameObject:
   - component: {fileID: 409360280}
   - component: {fileID: 409360279}
   - component: {fileID: 409360278}
+  - component: {fileID: 409360281}
   m_Layer: 0
   m_Name: SignInCanvas
   m_TagString: Untagged
@@ -266,6 +227,19 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!114 &409360281
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 409360276}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: be2b34b329cf0154c81c3cc384bd432b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _mappingSo: {fileID: 11400000, guid: d104d39fa3901d24f84d19a251668ef8, type: 2}
 --- !u!1 &411619619
 GameObject:
   m_ObjectHideFlags: 0
@@ -504,6 +478,86 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Padding: {x: -8, y: -5, z: -8, w: -5}
   m_Softness: {x: 0, y: 0}
+--- !u!21 &719130420
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
+    - _WidthHeightRadius: {r: 350, g: 70, b: 30, a: 0}
+  m_BuildTextureStacks: []
+--- !u!21 &855047656
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
+    - _WidthHeightRadius: {r: 700, g: 600, b: 80, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1 &872359663
 GameObject:
   m_ObjectHideFlags: 0
@@ -644,7 +698,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 2143248859}
+  m_Material: {fileID: 855047656}
   m_Color: {r: 0.5882353, g: 0.5882353, b: 0.5882353, a: 0.392}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
@@ -1058,7 +1112,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 1991897391}
+  m_Material: {fileID: 2050367901}
   m_Color: {r: 0.5882353, g: 0.5882353, b: 0.5882353, a: 0.392}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
@@ -1141,10 +1195,9 @@ MonoBehaviour:
   _downloadSlider: {fileID: 991575043}
   _downloadValueText: {fileID: 2092281466}
   _spriteLabel:
+  - m_LabelString: SignIn_UI
   - m_LabelString: Lobby_UI
   - m_LabelString: Lobby_CharImg
-  - m_LabelString: Stage_Foods
-  - m_LabelString: Stage_Ingredients
   - m_LabelString: InGame_UI
 --- !u!1 &1128301613
 GameObject:
@@ -1675,6 +1728,46 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1350539874}
   m_CullTransparentMesh: 1
+--- !u!21 &1401092496
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UI/RoundedCorners/RoundedCorners
+  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _ColorMask: 15
+    - _Stencil: 0
+    - _StencilComp: 8
+    - _StencilOp: 0
+    - _StencilReadMask: 255
+    - _StencilWriteMask: 255
+    - _UseUIAlphaClip: 0
+    m_Colors:
+    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
+    - _WidthHeightRadius: {r: 500, g: 400, b: 80, a: 0}
+  m_BuildTextureStacks: []
 --- !u!1 &1459362467
 GameObject:
   m_ObjectHideFlags: 0
@@ -1939,7 +2032,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 2067119933}
+  m_Material: {fileID: 719130420}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
@@ -2861,7 +2954,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_Material: {fileID: 117937862}
+  m_Material: {fileID: 1401092496}
   m_Color: {r: 0.5882353, g: 0.5882353, b: 0.5882353, a: 0.392}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
@@ -3080,7 +3173,7 @@ Transform:
   - {fileID: 1025024988}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &1991897391
+--- !u!21 &2050367901
 Material:
   serializedVersion: 8
   m_ObjectHideFlags: 0
@@ -3119,46 +3212,6 @@ Material:
     m_Colors:
     - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
     - _WidthHeightRadius: {r: 700, g: 600, b: 80, a: 0}
-  m_BuildTextureStacks: []
---- !u!21 &2067119933
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 350, g: 70, b: 30, a: 0}
   m_BuildTextureStacks: []
 --- !u!1 &2092281464
 GameObject:
@@ -3368,46 +3421,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &2143248859
-Material:
-  serializedVersion: 8
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: UI/RoundedCorners/RoundedCorners
-  m_Shader: {fileID: 4800000, guid: 0bd2ec5d73751e34a814274a454bec41, type: 3}
-  m_Parent: {fileID: 0}
-  m_ModifiedSerializedProperties: 0
-  m_ValidKeywords: []
-  m_InvalidKeywords: []
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_DoubleSidedGI: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_LockedProperties: 
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Ints: []
-    m_Floats:
-    - _ColorMask: 15
-    - _Stencil: 0
-    - _StencilComp: 8
-    - _StencilOp: 0
-    - _StencilReadMask: 255
-    - _StencilWriteMask: 255
-    - _UseUIAlphaClip: 0
-    m_Colors:
-    - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 700, g: 600, b: 80, a: 0}
-  m_BuildTextureStacks: []
 --- !u!1001 &2055466074370529690
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/06_SDW_Folder/Scripts/Addressable Sprite Loader/ImageSpriteLoader.cs
+++ b/Assets/06_SDW_Folder/Scripts/Addressable Sprite Loader/ImageSpriteLoader.cs
@@ -14,8 +14,11 @@ namespace SDW
         [Tooltip("씬별로 생성된 ImageSpriteMapping SO 할당")]
         public ImageSpriteMappingSO _mappingSo;
 
-        private void Awake()
+        private bool _isDownloaded;
+
+        private void Update()
         {
+            if (!GameManager.Instance.CompleteDownload || _isDownloaded) return;
 #if UNITY_EDITOR
             if (!Application.isPlaying)
             {
@@ -24,6 +27,8 @@ namespace SDW
             }
 #endif
             LoadFromAddressables();
+
+            _isDownloaded = true;
         }
 
 #if UNITY_EDITOR
@@ -31,17 +36,50 @@ namespace SDW
         {
             if (_mappingSo == null) return;
 
+            // 1) Image 처리
             var images = FindObjectsOfType<Image>(true);
             foreach (var img in images)
             {
-                string path = GetPath(img.gameObject);
-                var entry = _mappingSo.entries.Find(e => e.Path == path);
-                if (entry == null || string.IsNullOrEmpty(entry.AssetPath)) continue;
-
-                var sprite = AssetDatabase.LoadAssetAtPath<Sprite>(entry.AssetPath);
-                if (sprite != null)
-                    img.sprite = sprite;
+                ApplyEditorSprite(img.gameObject, sprite => img.sprite = sprite);
             }
+
+            // 2) MonoBehaviour Sprite 필드 처리
+            var monos = FindObjectsOfType<MonoBehaviour>(true);
+            foreach (var mb in monos)
+            {
+                if (mb == null) continue;
+                var so = new SerializedObject(mb);
+                var prop = so.GetIterator();
+                bool modified = false;
+
+                while (prop.NextVisible(true))
+                {
+                    if (prop.propertyType == SerializedPropertyType.ObjectReference &&
+                        prop.objectReferenceValue is Sprite)
+                    {
+                        var p = prop.Copy(); // 클로저 안전 복사
+                        ApplyEditorSprite(mb.gameObject, sprite =>
+                        {
+                            p.objectReferenceValue = sprite;
+                            modified = true;
+                        });
+                    }
+                }
+
+                if (modified)
+                    so.ApplyModifiedProperties();
+            }
+        }
+
+        private void ApplyEditorSprite(GameObject owner, System.Action<Sprite> assign)
+        {
+            string path = GetPath(owner);
+            var entry = _mappingSo.entries.Find(e => e.Path == path);
+            if (entry == null || string.IsNullOrEmpty(entry.AssetPath)) return;
+
+            var sprite = AssetDatabase.LoadAssetAtPath<Sprite>(entry.AssetPath);
+            if (sprite != null)
+                assign(sprite);
         }
 #endif
 
@@ -49,28 +87,48 @@ namespace SDW
         {
             if (_mappingSo == null) return;
 
+            // 1) Image 처리
             var images = GetComponentsInChildren<Image>(true);
             foreach (var img in images)
             {
-                string path = GetPath(img.gameObject);
-                var entry = _mappingSo.entries.Find(e => e.Path == path);
-                if (entry == null || string.IsNullOrEmpty(entry.AddressKey)) continue;
-
-                //# 런타임에서는 Addressables로만 로드 (주소 키=GUID)
-                img.sprite = null;
-
-                Addressables.LoadAssetAsync<Sprite>(entry.AddressKey).Completed += (AsyncOperationHandle<Sprite> handle) =>
-                {
-                    if (handle.Status == AsyncOperationStatus.Succeeded)
-                    {
-                        img.sprite = handle.Result;
-                    }
-                    else
-                    {
-                        Debug.LogError($"[ImageSpriteLoader] Load failed: {entry.AddressKey} (path: {path})");
-                    }
-                };
+                LoadSpriteFromAddressables(img.gameObject, sprite => img.sprite = sprite);
             }
+
+            // 2) MonoBehaviour Sprite 필드 처리 (런타임: Reflection)
+            var monos = GetComponentsInChildren<MonoBehaviour>(true);
+            foreach (var mb in monos)
+            {
+                if (mb == null) continue;
+                var fields = mb.GetType().GetFields(
+                    System.Reflection.BindingFlags.Public |
+                    System.Reflection.BindingFlags.NonPublic |
+                    System.Reflection.BindingFlags.Instance);
+
+                foreach (var field in fields)
+                {
+                    if (field.FieldType == typeof(Sprite))
+                    {
+                        LoadSpriteFromAddressables(mb.gameObject, sprite => { field.SetValue(mb, sprite); });
+                    }
+                }
+            }
+        }
+
+        private void LoadSpriteFromAddressables(GameObject owner, System.Action<Sprite> assign)
+        {
+            string path = GetPath(owner);
+            var entry = _mappingSo.entries.Find(e => e.Path == path);
+            if (entry == null || string.IsNullOrEmpty(entry.AddressKey)) return;
+
+            assign(null); // 런타임에서는 우선 제거
+
+            Addressables.LoadAssetAsync<Sprite>(entry.AddressKey).Completed += (handle) =>
+            {
+                if (handle.Status == AsyncOperationStatus.Succeeded)
+                    assign(handle.Result);
+                else
+                    Debug.LogError($"[ImageSpriteLoader] Load failed: {entry.AddressKey} (path: {path})");
+            };
         }
 
         private static string GetPath(GameObject go)

--- a/Assets/06_SDW_Folder/Scripts/Manager/GameManager.cs
+++ b/Assets/06_SDW_Folder/Scripts/Manager/GameManager.cs
@@ -35,6 +35,9 @@ namespace SDW
         [SerializeField] private string _stageName;
         public string StageName => _stageName;
 
+        private bool _completeDownload;
+        public bool CompleteDownload => _completeDownload;
+
         private bool _lastBoss;
         public bool LastBoss => _lastBoss;
 
@@ -91,5 +94,7 @@ namespace SDW
         public void SetRainbowStarCandy(int number) => rainbowStarCandy = number;
 
         public void AddGachaCount(int number) => _gachaCount += number;
+
+        public void SetCompleteDownload(bool complete) => _completeDownload = complete;
     }
 }

--- a/Assets/06_SDW_Folder/Scripts/UI/SignInScene/DownloadUI.cs
+++ b/Assets/06_SDW_Folder/Scripts/UI/SignInScene/DownloadUI.cs
@@ -65,6 +65,10 @@ namespace SDW
         {
             var init = Addressables.InitializeAsync(true);
             yield return init;
+
+            // Remote 카탈로그 업데이트
+            var catalogHandle = Addressables.UpdateCatalogs();
+            yield return catalogHandle;
         }
 
         #region Check Download
@@ -77,6 +81,7 @@ namespace SDW
             {
                 if (!LabelExists(label.labelString)) continue;
                 labels.Add(label.labelString);
+                Debug.Log($"Label : {label.labelString}");
             }
 
             _patchSize = default;
@@ -85,6 +90,7 @@ namespace SDW
             {
                 var handle = Addressables.GetDownloadSizeAsync(label);
                 yield return handle;
+                Debug.Log($"{label} : {handle.Result}");
 
                 _patchSize += handle.Result;
             }
@@ -102,6 +108,7 @@ namespace SDW
             {
                 _downloadValueText.text = "100%";
                 _downloadSlider.value = 1f;
+                GameManager.Instance.SetCompleteDownload(true);
                 yield return new WaitForSeconds(0.5f);
 
                 OnUIOpenRequested?.Invoke(UIName.SignInUI);
@@ -155,13 +162,13 @@ namespace SDW
 
             foreach (string label in labels)
             {
-                var handle = Addressables.GetDownloadSizeAsync(label);
-                yield return handle;
-
-                if (handle.Result != decimal.Zero)
-                {
-                    StartCoroutine(DownloadLabel(label));
-                }
+                // var handle = Addressables.GetDownloadSizeAsync(label);
+                // yield return handle;
+                //
+                // if (handle.Result != decimal.Zero)
+                // {
+                StartCoroutine(DownloadLabel(label));
+                // }
             }
 
             yield return CheckDownload();
@@ -169,6 +176,7 @@ namespace SDW
 
         private IEnumerator DownloadLabel(string label)
         {
+            Debug.Log($"Download : {label}");
             _patchMap.Add(label, 0);
 
             var handle = Addressables.DownloadDependenciesAsync(label, false);
@@ -183,24 +191,49 @@ namespace SDW
             Addressables.Release(handle);
         }
 
+        // private IEnumerator CheckDownload()
+        // {
+        //     float total = 0f;
+        //     _downloadValueText.text = "0 %";
+        //
+        //     while (true)
+        //     {
+        //         total += _patchMap.Sum(tmp => tmp.Value);
+        //
+        //         _downloadSlider.value = total / _patchSize;
+        //         _downloadValueText.text = (int)(_downloadSlider.value * 100) + "%";
+        //
+        //         if (total == _patchSize) break;
+        //
+        //         total = 0f;
+        //         yield return new WaitForEndOfFrame();
+        //     }
+        //
+        //     OnUIOpenRequested?.Invoke(UIName.SignInUI);
+        //     OnUICloseRequested?.Invoke(UIName.DownloadUI);
+        // }
+
         private IEnumerator CheckDownload()
         {
-            float total = 0f;
-            _downloadValueText.text = "0 %";
+            _downloadValueText.text = "0%";
 
             while (true)
             {
-                total += _patchMap.Sum(tmp => tmp.Value);
+                // 매 프레임마다 합계 새로 계산
+                long downloaded = _patchMap.Sum(tmp => tmp.Value);
 
-                _downloadSlider.value = total / _patchSize;
-                _downloadValueText.text = (int)(_downloadSlider.value * 100) + "%";
+                float progress = (float)downloaded / _patchSize;
+                _downloadSlider.value = progress;
+                _downloadValueText.text = (int)(progress * 100) + "%";
 
-                if (total == _patchSize) break;
+                if (downloaded >= _patchSize)
+                    break;
 
-                total = 0f;
-                yield return new WaitForEndOfFrame();
+                yield return null; // 매 프레임 갱신
             }
 
+            GameManager.Instance.SetCompleteDownload(true);
+            // 다운로드 완료 시 다음 UI로
             OnUIOpenRequested?.Invoke(UIName.SignInUI);
             OnUICloseRequested?.Invoke(UIName.DownloadUI);
         }

--- a/Assets/AddressableAssetsData/AddressableAssetSettings.asset
+++ b/Assets/AddressableAssetsData/AddressableAssetSettings.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   m_DefaultGroup: 6e29a68307d558b48bb739f4a265f55a
   m_currentHash:
     serializedVersion: 2
-    Hash: 00000000000000000000000000000000
+    Hash: 7521620dfbe49e7532e57c0a4e2006b3
   m_OptimizeCatalogSize: 0
   m_BuildRemoteCatalog: 1
   m_BundleLocalCatalog: 0
@@ -44,6 +44,7 @@ MonoBehaviour:
   m_BuildAddressablesWithPlayerBuild: 0
   m_overridePlayerVersion: '[UnityEditor.PlayerSettings.bundleVersion]'
   m_GroupAssets:
+  - {fileID: 11400000, guid: dfe184efbca417340898a27911a0de48, type: 2}
   - {fileID: 11400000, guid: 49ba3c976ceb85749969c0f7809cdd01, type: 2}
   - {fileID: 11400000, guid: ccfcecf9e1a9da94899438e582d1781e, type: 2}
   - {fileID: 11400000, guid: 9ed338bc79311fc4f9ade027d5c6ce7e, type: 2}
@@ -94,6 +95,7 @@ MonoBehaviour:
     - InGame_UI
     - Stage_Foods
     - Stage_Ingredients
+    - SignIn_UI
   m_SchemaTemplates: []
   m_GroupTemplateObjects:
   - {fileID: 11400000, guid: bda71db4be1e3f346a06bcd06c971d01, type: 2}

--- a/Assets/AddressableAssetsData/AssetGroups/RemoteInGameSprites.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/RemoteInGameSprites.asset
@@ -41,6 +41,12 @@ MonoBehaviour:
     m_SerializedLabels:
     - InGame_UI
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 1d7501232a26f3d4ba68eb61c8ac5dcf
+    m_Address: 1d7501232a26f3d4ba68eb61c8ac5dcf
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - InGame_UI
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 335f7c7ba8037d54386f17ba306f438f
     m_Address: 335f7c7ba8037d54386f17ba306f438f
     m_ReadOnly: 0

--- a/Assets/AddressableAssetsData/AssetGroups/RemoteLobbySprites.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/RemoteLobbySprites.asset
@@ -111,7 +111,6 @@ MonoBehaviour:
     m_Address: d5448dba9da6a1842a72be7b75a3b29a
     m_ReadOnly: 0
     m_SerializedLabels:
-    - Lobby_CharImg
     - Lobby_UI
     FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: e354caf3995476148b31593e9d16161c

--- a/Assets/AddressableAssetsData/AssetGroups/RemoteSignInSprites.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/RemoteSignInSprites.asset
@@ -1,0 +1,43 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bbb281ee3bf0b054c82ac2347e9e782c, type: 3}
+  m_Name: RemoteSignInSprites
+  m_EditorClassIdentifier: 
+  m_GroupName: RemoteSignInSprites
+  m_Data:
+    m_SerializedData: []
+  m_GUID: 3e2811eb999b07243bff31a9169aef38
+  m_SerializeEntries:
+  - m_GUID: 38b5fc1248630a14996dee5d1b079485
+    m_Address: 38b5fc1248630a14996dee5d1b079485
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - SignIn_UI
+    FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 8600060538fce3a4aaf99e87c0c7871f
+    m_Address: 8600060538fce3a4aaf99e87c0c7871f
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - SignIn_UI
+    FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 9dabe2e845efb504eb745e1ce37cff58
+    m_Address: 9dabe2e845efb504eb745e1ce37cff58
+    m_ReadOnly: 0
+    m_SerializedLabels:
+    - SignIn_UI
+    FlaggedDuringContentUpdateRestriction: 0
+  m_ReadOnly: 0
+  m_Settings: {fileID: 11400000, guid: 441dd7bf659100a4990a849b99ef5569, type: 2}
+  m_SchemaSet:
+    m_Schemas:
+    - {fileID: 11400000, guid: 27ce968236277f6448fa9fb2f090b685, type: 2}
+    - {fileID: 11400000, guid: d061933c8e356c847ab2fb6fb389e132, type: 2}

--- a/Assets/AddressableAssetsData/AssetGroups/RemoteSignInSprites.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/RemoteSignInSprites.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dfe184efbca417340898a27911a0de48
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/RemoteSignInSprites_BundledAssetGroupSchema.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/RemoteSignInSprites_BundledAssetGroupSchema.asset
@@ -1,0 +1,45 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e5d17a21594effb4e9591490b009e7aa, type: 3}
+  m_Name: RemoteSignInSprites_BundledAssetGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 11400000, guid: dfe184efbca417340898a27911a0de48, type: 2}
+  m_InternalBundleIdMode: 1
+  m_Compression: 1
+  m_IncludeAddressInCatalog: 1
+  m_IncludeGUIDInCatalog: 1
+  m_IncludeLabelsInCatalog: 1
+  m_InternalIdNamingMode: 0
+  m_CacheClearBehavior: 1
+  m_IncludeInBuild: 1
+  m_BundledAssetProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.BundledAssetProvider
+  m_ForceUniqueProvider: 0
+  m_UseAssetBundleCache: 1
+  m_UseAssetBundleCrc: 1
+  m_UseAssetBundleCrcForCachedBundles: 1
+  m_UseUWRForLocalBundles: 0
+  m_Timeout: 0
+  m_ChunkedTransfer: 0
+  m_RedirectLimit: -1
+  m_RetryCount: 0
+  m_BuildPath:
+    m_Id: 9901116e2093b9b4c92991ef8525000a
+  m_LoadPath:
+    m_Id: 7069ebb5acb4d424496761e854400418
+  m_BundleMode: 0
+  m_AssetBundleProviderType:
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.AssetBundleProvider
+  m_BundleNaming: 0
+  m_AssetLoadMode: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/RemoteSignInSprites_BundledAssetGroupSchema.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/RemoteSignInSprites_BundledAssetGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 27ce968236277f6448fa9fb2f090b685
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/RemoteSignInSprites_ContentUpdateGroupSchema.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/RemoteSignInSprites_ContentUpdateGroupSchema.asset
@@ -1,0 +1,16 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5834b5087d578d24c926ce20cd31e6d6, type: 3}
+  m_Name: RemoteSignInSprites_ContentUpdateGroupSchema
+  m_EditorClassIdentifier: 
+  m_Group: {fileID: 11400000, guid: dfe184efbca417340898a27911a0de48, type: 2}
+  m_StaticContent: 0

--- a/Assets/AddressableAssetsData/AssetGroups/Schemas/RemoteSignInSprites_ContentUpdateGroupSchema.asset.meta
+++ b/Assets/AddressableAssetsData/AssetGroups/Schemas/RemoteSignInSprites_ContentUpdateGroupSchema.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d061933c8e356c847ab2fb6fb389e132
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
* Image 뿐만 아니라 MonoBehaviour 스크립트 내 Sprite도 Addressable에서 관리하도록 추가한 후 다운로드가 완료되지 않는 버그
  * DownLoadUI가 Sign In 보다 먼저 실행되면서 ImageSpriteLoader의 Awake에서 호출하는 Sprite 연결 작업이 다운로드 전에 이루어지면서 발생하는 문제
  * GameManager에 Donwload 완료 관련 flag를 추가하여, 완료된 이후 download 되도록 변경 후 해결

---

# 체크리스트
- [x] 코드가 정상적으로 빌드/실행된다
- [x] 기능이 정상 동작한다
- [x] 심각한 버그나 예상치 못한 문제는 없다