### PR TITLE
[Fix] Build Test 4EA Bug Fix

### DIFF
--- a/Assets/05_KGW_Folder/Scripts/Characters/CharacterAttackController.cs
+++ b/Assets/05_KGW_Folder/Scripts/Characters/CharacterAttackController.cs
@@ -66,7 +66,11 @@ public class CharacterAttackController : MonoBehaviour
         foreach (MonsterController monster in _controller._attackTargets)
         {
             // 몬스터가 없거나 죽었으면 넘어가기
-            if (monster == null || !monster.isActiveAndEnabled) continue;
+            if (monster == null || !monster.isActiveAndEnabled)
+            {
+                Debug.Log("공격 대상 몬스터가 없습니다.");
+                continue;
+            }
 
             // 몬스터와 거리 확인
             float distance = Vector3.SqrMagnitude(monster.transform.position - transform.position);

--- a/Assets/05_KGW_Folder/Scripts/Characters/CharacterState.cs
+++ b/Assets/05_KGW_Folder/Scripts/Characters/CharacterState.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using SDW;
 using UnityEngine;
 
 [Serializable]
@@ -9,6 +10,9 @@ public class CharacterState
     [Header("Character Base Data")]
     public int _chaID;
     public string _chaName;
+    public CharacterEnName _chaEnName;
+    public CharacterGrade _chaGrade;
+    public CharacterRole _chaRole;
     public int _chaLevel;
     public float _chaCurrentHP;
     public float _chaMaxHP;

--- a/Assets/05_KGW_Folder/Scripts/Characters/MyCharacterController.cs
+++ b/Assets/05_KGW_Folder/Scripts/Characters/MyCharacterController.cs
@@ -23,6 +23,7 @@ public class MyCharacterController : UnitBaseData
 
     private Coroutine _manaRoutine;
     private float _manaChangeValue;
+    private MyCharacterController _chaCon;
 
     // 체력과 마나의 변화 이벤트
     public event Action<float> OnHpChange;
@@ -30,15 +31,24 @@ public class MyCharacterController : UnitBaseData
 
     // 스킬 사용 모드 변화 이벤트
     public event Action<bool> OnSkillModeChange;
-
     // 유물 효과 적용 이벤트
     public event Action OnRelicEffect;
 
+    protected override void Awake()
+    {
+        base.Awake();
+
+        _attackController.RecheckAttackTarget();
+        _chaCon = GetComponent<MyCharacterController>();
+    }
     // 캐릭터 생성 초기화
     protected override void Init()
     {
         _characterState._chaID = _characterData._chaBaseData.ChaID;
         _characterState._chaName = _characterData._chaBaseData.ChaName;
+        _characterState._chaEnName = _characterData._chaBaseData.ChaEnName;
+        _characterState._chaGrade = _characterData._chaBaseData.ChaGrade;
+        _characterState._chaRole = _characterData._chaBaseData.ChaRole;
         _characterState._chaLevel = _characterData._chaLv;
         _characterState._chaCurrentHP = _characterData._chaBaseData.ChaHP;
         _characterState._chaMaxHP = _characterData._chaBaseData.ChaHP;
@@ -61,14 +71,20 @@ public class MyCharacterController : UnitBaseData
         // 체력, 마나 게이지 현재값 초기화
         OnHpChange?.Invoke(_characterState._chaCurrentHP / _characterState._chaMaxHP);
         OnMpChange?.Invoke(_characterState._chaCurrentMP / _characterState._chaMaxMP);
+        // 타임오버에 대한 캐릭터 삭제 이벤트 구독
+        _battleUI.OnTimeOver += TimeDeath;
+        _attackCoolTimer = _characterState._chaAtkSpeed;
 
         _manaChangeValue = _characterState._chaMPRecovery;
-        _chaData = _characterData;
-
-        _attackController.RecheckAttackTarget();
-
         // 마나 충전 
         ManaRecovery();
+    }
+
+    private void OnDestroy()
+    {
+        // 타임오버에 대한 캐릭터 삭제 이벤트 구독 해제
+        _battleUI.OnTimeOver -= TimeDeath;
+
     }
 
     // 캐릭터 이동
@@ -126,19 +142,35 @@ public class MyCharacterController : UnitBaseData
         // 공격 타겟과 거리 비교
         float attackDistance = Vector3.Distance(transform.position, _attackTarget.transform.position);
 
+        Debug.Log($"attackSpareDistance : {attackSpareDistance}, attackDistance : {attackDistance}");
+        Debug.Log($"_attackCoolTimer : {_attackCoolTimer}");
+
         // 공격 대상의 거리가 캐릭터의 공격 사거리에 들어오면 타겟 공격
-        if (attackDistance < attackSpareDistance && _attackCoolTimer <= 0f)
+        if (attackDistance <= attackSpareDistance)
         {
-            // 캐릭터의 데미지로 몬스터에 주기
-            _attackTarget.TakeDamage(_characterState._chaAttack);
+            Debug.Log("사거리 안에 들어옴");
 
-            _isAttack = true;
+            if(_attackCoolTimer <= 0f)
+            {
+                Debug.Log("공격 쿨타임 O");
 
-            // 공격 쿨타임 초기화
-            _attackCoolTimer = _characterState._chaAtkSpeed / _gameSpeed;
+                // 캐릭터의 데미지로 몬스터에 주기
+                _attackTarget.TakeDamage(_characterState._chaAttack);
+                _attackTarget.AttackTargetChange(_chaCon);
+
+                _isAttack = true;
+
+                // 공격 쿨타임 초기화
+                _attackCoolTimer = _characterState._chaAtkSpeed / _gameSpeed;
+            }
+            else
+            {
+                Debug.Log("공격 쿨타임 X");
+            }
         }
         else
         {
+            Debug.Log("사거리 안에 들어오지 못함");
             _isAttack = false;
         }
     }
@@ -223,14 +255,21 @@ public class MyCharacterController : UnitBaseData
     protected override void Death()
     {
         base.Death();
-        _attackTarget = null;
-        _attackTargets.Clear();
 
         OnSkillModeChange?.Invoke(_isAlive);
 
         StopManaRecovery();
         // 매니저에 사망 보고
         _battleManager.CharacterDeathCheck();
+    }
+
+    // 타임오버 시 캐릭터 사망
+    public void TimeDeath(bool timeOver)
+    {
+        if (timeOver)
+        {
+            base.Death();
+        }
     }
 
     // 마나 회복

--- a/Assets/05_KGW_Folder/Scripts/IntegratedScripts/UnitBaseData.cs
+++ b/Assets/05_KGW_Folder/Scripts/IntegratedScripts/UnitBaseData.cs
@@ -24,7 +24,7 @@ public abstract class UnitBaseData : MonoBehaviour
     protected CharacterDataSO _chaData;
     protected MonsterDataSO _monData;
     
-    private void Awake()
+    protected virtual void Awake()
     {
         _battleManager = FindObjectOfType<BattleManager>();
         _battleUI = FindObjectOfType<BattleUI>();

--- a/Assets/05_KGW_Folder/Scripts/Manager/Battle/BattleManager.cs
+++ b/Assets/05_KGW_Folder/Scripts/Manager/Battle/BattleManager.cs
@@ -50,6 +50,7 @@ public class BattleManager : MonoBehaviour
     public int _characterCount;
     public bool _isClear;
     public bool _isGameOver;
+    public bool _isTimeOver;
     public bool _canResurrection;
     public int _timer;
     public float _monsterTotalMaxHp;

--- a/Assets/05_KGW_Folder/Scripts/Manager/Battle/BattleUI.cs
+++ b/Assets/05_KGW_Folder/Scripts/Manager/Battle/BattleUI.cs
@@ -32,12 +32,14 @@ public class BattleUI : BaseUI
     public float _currentTotalHp;
     public float _TotalHp;
     public bool _isOnMenu;
+    private float _speed;
 
     public float _time;
     private bool _isFast;
     private Coroutine _timerRoutine;
 
     public Action<UIName> OnUIOpenRequested;
+    public event Action<bool> OnTimeOver;
 
     private void Awake()
     {
@@ -135,10 +137,10 @@ public class BattleUI : BaseUI
     private void ChangeGameTimer()
     {
         // 게임 스피드 설정
-        float speed = CharacterSelectManager.Instance._isFastGame ? 2f : 1f;
+        _speed = CharacterSelectManager.Instance._isFastGame ? 2f : 1f;
 
         // 타이머 1배속, 2배속 세팅
-        _playTime = new WaitForSeconds(1f / speed);
+        _playTime = new WaitForSeconds(1f / _speed);
     }
 
     // X2 속도 버튼 클릭
@@ -212,12 +214,29 @@ public class BattleUI : BaseUI
                     Debug.Log("클리어 실패!");
                     _battleManager._isClear = false;
                     _battleManager._isGameOver = true;
+                    _battleManager._isTimeOver = true;
+
+                    // 타임오버 시 
+                    OnTimeOver?.Invoke(_battleManager._isTimeOver);
 
                     // 클리어 실패 UI 오픈
                     GamePlayResultCheck(_battleManager._isClear);
                 }
+                yield return null;
             }
         }
+    }
+
+    public void StartTimeCoroutine()
+    {
+        if(_timerRoutine != null)
+        {
+            StopCoroutine(_timerRoutine);
+            _timerRoutine = null;
+        }
+
+        _playTime = new WaitForSeconds(1f / _speed);
+        _timerRoutine = StartCoroutine(TimerCoroutine());
     }
 
     // 타이머 코루틴 정지

--- a/Assets/05_KGW_Folder/Scripts/Monsters/MonsterController.cs
+++ b/Assets/05_KGW_Folder/Scripts/Monsters/MonsterController.cs
@@ -8,7 +8,7 @@ using UnityEngine.UI;
 public class MonsterController : UnitBaseData
 {
     [Header("Monster Data Setting")]
-    [SerializeField] public MonsterDataSO _monsterData; // 몬스터 데이터
+    [SerializeField] MonsterDataSO _monsterData; // 몬스터 데이터
     [SerializeField] private Slider _monsterHp;
 
     [Header("Attack Unit List")]
@@ -39,6 +39,8 @@ public class MonsterController : UnitBaseData
     {
         _monsterState._monID = _monsterData.MonId;
         _monsterState._monName = _monsterData.MonName;
+        _monsterState._monEnName = _monsterData.MonEnName;
+        _monsterState._monType = _monsterData.MonType;
         _monsterState._monLevel = _monsterData.MonLv;
         _monsterState._monCurrentHP = _monsterData.MonHP;
         _monsterState._monMaxHP = _monsterData.MonHP;
@@ -51,9 +53,15 @@ public class MonsterController : UnitBaseData
         _monsterState._monAvoid = _monsterData.MonAvoid;
         _monsterState._monReg = _monsterData.MonReg;
 
+        _monsterState._monHPIncrase = _monsterData.MonHPIncrase;
+        _monsterState._monAttackIncrease = _monsterData.MonAttackIncrease;
+        _monsterState._monArmorIncrease = _monsterData.MonArmorIncrease;
+        _monsterState._monAvoidIncrease = _monsterData.MonAvoidIncrease;
+
         _moveDir = Vector3.left;
         _isAlive = true;
         _monData = _monsterData;
+        _attackCoolTimer = _monsterState._monAtkSpeed;
         _recallPointProvider = GetComponent<RecallPointProvider>();
 
         // 보스 체력 절반에서의 소환스킬 사용 관련 이벤트 구독
@@ -143,7 +151,7 @@ public class MonsterController : UnitBaseData
             float attackDistance = Vector3.Distance(transform.position, _attackTarget.transform.position);
 
             // 공격 대상의 거리가 몬스터의 공격 사거리에 들어오면 타겟 공격
-            if (attackDistance < attackSpareDistance && _attackCoolTimer <= 0f)
+            if (attackDistance <= attackSpareDistance && _attackCoolTimer <= 0f)
             {
                 // 몬스터의 데미지로 캐릭터에 주기
                 _attackTarget.TakeDamage(_monsterState._monAttack);
@@ -267,5 +275,15 @@ public class MonsterController : UnitBaseData
             // 매니저에 사망 보고
             _battleManager.MonsterDeathCheck();
         }
+    }
+
+    // 공격 대상 변경
+    public void AttackTargetChange(MyCharacterController chaData)
+    {
+        // 공격한 캐릭터가 죽었으면 넘어가기
+        if (chaData == null || !chaData.isActiveAndEnabled) return;
+
+        // 공격 대상 전환
+        _attackTarget = chaData;
     }
 }

--- a/Assets/05_KGW_Folder/Scripts/Monsters/MonsterState.cs
+++ b/Assets/05_KGW_Folder/Scripts/Monsters/MonsterState.cs
@@ -1,6 +1,8 @@
 using System;
+using System.CodeDom.Compiler;
 using System.Collections;
 using System.Collections.Generic;
+using SDW;
 using UnityEngine;
 
 [Serializable]
@@ -9,7 +11,11 @@ public class MonsterState
     [Header("Monster Stat Data")]
     public int _monID;
     public string _monName;
+    public MonsterEnName _monEnName;
+    public MonsterType _monType;
     public int _monLevel;
+    public bool _monBreak;
+    public float _breakGage;
     public float _monCurrentHP;
     public float _monMaxHP;
     public int _monAtkRange;
@@ -20,4 +26,10 @@ public class MonsterState
     public float _monAccuracy;
     public float _monAvoid;
     public float _monReg;
+
+    [Header("Monster Stat Increase")]
+    public float _monHPIncrase;
+    public float _monAttackIncrease;
+    public float _monArmorIncrease;
+    public float _monAvoidIncrease;
 }

--- a/Assets/05_KGW_Folder/Scripts/UI/ResurrectionUI/NonRemoveADUI.cs
+++ b/Assets/05_KGW_Folder/Scripts/UI/ResurrectionUI/NonRemoveADUI.cs
@@ -79,19 +79,22 @@ public class NonRemoveADUI : BaseUI
     // 캐릭터 부활
     private void CharacterResurrection()
     {
-        // 게임 진행 상황 초기화
-        _battleManager._canResurrection = false;
-        _battleManager._isClear = false;
-        _battleManager._isGameOver = false;
-        _battleManager._characters.Clear();
-
-        // 게임 시간이 0이면 게임 시간 초기화
-        if (_battleManager._battleUI._time <= 0f)
+        // 타임오버로 게임 종료면 게임 시간 초기화
+        if (_battleManager._isTimeOver)
         {
             _battleManager._battleUI._time = _battleManager._timer;
         }
 
+        // 게임 진행 상황 초기화
+        _battleManager._isGameOver = false;
+        _battleManager._isClear = false;
+        _battleManager._isTimeOver = false;
+        _battleManager._canResurrection = false;
+
+        _battleManager._characters.Clear();
         _battleManager.CharacterSpawn();
+
+        _battleManager._battleUI.StartTimeCoroutine();
     }
 
     private void ConfirmButtonClicked()

--- a/Assets/05_KGW_Folder/Scripts/UI/ResurrectionUI/RemoveADUI.cs
+++ b/Assets/05_KGW_Folder/Scripts/UI/ResurrectionUI/RemoveADUI.cs
@@ -60,19 +60,22 @@ public class RemoveADUI : BaseUI
     // 캐릭터 부활
     private void CharacterResurrection()
     {
-        // 게임 진행 상황 초기화
-        _battleManager._canResurrection = false;
-        _battleManager._isClear = false;
-        _battleManager._isGameOver = false;
-        _battleManager._characters.Clear();
-
-        // 게임 시간이 0이면 게임 시간 초기화
-        if(_battleManager._battleUI._time <= 0f)
+        // 타임오버로 게임 종료면 게임 시간 초기화
+        if (_battleManager._isTimeOver)
         {
             _battleManager._battleUI._time = _battleManager._timer;
         }
 
+        // 게임 진행 상황 초기화
+        _battleManager._isGameOver = false;
+        _battleManager._isClear = false;
+        _battleManager._isTimeOver = false;
+        _battleManager._canResurrection = false;
+
+        _battleManager._characters.Clear();
         _battleManager.CharacterSpawn();
+
+        _battleManager._battleUI.StartTimeCoroutine();
     }
 
     // 노 버튼 클릭


### PR DESCRIPTION
요약
(이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요)
- 빌드 테스트에서 발생한 원활한 게임 진행에 영향을 주는  4가지 버그 수정

작업 내용
(이 PR에서 어떤 작업이 있었는지 작성해주세요)
1. 타임오버로 게임오버 상태에서 광고를 보고 부활하여 리스타트 시 캐릭터의 중복 생성 버그 확인 수정
   - 게임오버시 기존에 플레이하던 캐릭터가 남아있고 새로 스폰을 하다보니 생기는 버그로 게임오버시 이벤트를 활용하여 기존남아있던 캐릭터 삭제 

2. 몬스터가 캐릭터 한명만 밀고 들어가는 부자연스러운 전투로 몬스터 타겟 지정 수정
   - 몬스터가 처음 타겟을 잡고 공격을 하는데 1명의 캐릭터에게 타겟이 잡히는 원인 파악하여 자신을 공격하는 플레이어를 타겟으로 잡도록 수정
  
3. 타임오버로 부활시 타이머가 초기화 안되는 버그 확인 수정
   - 타이머를 코루틴으로 돌리는데 부활시 Start를 하지 않아 발생하여 Start를 담당하는 함수를 만들어 호출하여 수정
 
4. 부활시 캐릭터가 몬스터를 공격하지 않는 버그 확인 수정
   - 공격 타겟에는 문제가 없고 공격 쿨타임에서 초기화를 하지 않아 쿨타임 치수가 인피니티로 측정되어 조건에 벗어나 공격을 하지 못하는 원인 파악하여 수정 

체크리스트
 코드가 정상적으로 빌드/실행된다
 기능이 정상 동작한다
 심각한 버그나 예상치 못한 문제는 없다