### PR TITLE
[Feat] Add Character Passive, Active Skill

### DIFF
--- a/Assets/05_KGW_Folder/Prefabs/00_Characters/BCA.prefab
+++ b/Assets/05_KGW_Folder/Prefabs/00_Characters/BCA.prefab
@@ -85,6 +85,7 @@ MonoBehaviour:
   _attackCoolTimer: 0
   _moveDir: {x: 0, y: 0, z: 0}
   _gameSpeed: 0
+  _battleManager: {fileID: 0}
   _characterData: {fileID: 11400000, guid: 0977072b4d0ff2c4bb1c250d908f0ba6, type: 2}
   _attackController: {fileID: 6392717553107434659}
   _attackTargets: []
@@ -93,6 +94,9 @@ MonoBehaviour:
   _characterState:
     _chaID: 0
     _chaName: 
+    _chaEnName: 0
+    _chaGrade: 0
+    _chaRole: 0
     _chaLevel: 0
     _chaCurrentHP: 0
     _chaMaxHP: 0
@@ -102,6 +106,8 @@ MonoBehaviour:
     _chaAtkSpeed: 0
     _chaAttack: 0
     _chaArmor: 0
+    _isBarrier: 0
+    _groggyDamage: 0
     _chaAtkIsMelee: 0
     _chaAccuracy: 0
     _chaAvoid: 0
@@ -109,6 +115,8 @@ MonoBehaviour:
     _chaCritDmg: 0
     _chaReg: 0
     _chaMoveSpeed: 0
+    _chaPassiveSkill: {fileID: 11400000, guid: 225cf737d40a09d48b2ddce59168cd9a, type: 2}
+    _chaActiveSkill: {fileID: 11400000, guid: 4a2c293d48547944daadf326f357d3c6, type: 2}
     _isManaFull: 0
 --- !u!70 &3348997761910632104
 CapsuleCollider2D:

--- a/Assets/05_KGW_Folder/Prefabs/00_Characters/BW.prefab
+++ b/Assets/05_KGW_Folder/Prefabs/00_Characters/BW.prefab
@@ -166,6 +166,7 @@ MonoBehaviour:
   _attackCoolTimer: 0
   _moveDir: {x: 0, y: 0, z: 0}
   _gameSpeed: 0
+  _battleManager: {fileID: 0}
   _characterData: {fileID: 11400000, guid: 103b7f3043d88a9429d25209c9d1f182, type: 2}
   _attackController: {fileID: 946221221693280591}
   _attackTargets: []
@@ -186,6 +187,8 @@ MonoBehaviour:
     _chaAtkSpeed: 0
     _chaAttack: 0
     _chaArmor: 0
+    _isBarrier: 0
+    _groggyDamage: 0
     _chaAtkIsMelee: 0
     _chaAccuracy: 0
     _chaAvoid: 0
@@ -193,6 +196,8 @@ MonoBehaviour:
     _chaCritDmg: 0
     _chaReg: 0
     _chaMoveSpeed: 0
+    _chaPassiveSkill: {fileID: 11400000, guid: 47189edbb54ca18499e51caaa3eb7486, type: 2}
+    _chaActiveSkill: {fileID: 11400000, guid: 0e1f6a269f20a784ca12b6ae5669cda8, type: 2}
     _isManaFull: 0
 --- !u!70 &6360715837677692393
 CapsuleCollider2D:

--- a/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/BCA_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/BCA_Data.asset
@@ -42,7 +42,7 @@ MonoBehaviour:
   _prefab: {fileID: 315290852922950502, guid: e2d9fb0ff2abe3a4caac52a1c5bcc451, type: 3}
   _chaLv: 1
   _chaSkills: []
-  _chaActiveSkill: {fileID: 0}
+  _chaActiveSkill: {fileID: 11400000, guid: 4a2c293d48547944daadf326f357d3c6, type: 2}
   _chaPassiveSkill: {fileID: 11400000, guid: 225cf737d40a09d48b2ddce59168cd9a, type: 2}
   Beads: 0
   GachaBackground: {fileID: 21300000, guid: 130367da1bf541340908399ee44a9855, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/BW_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/BW_Data.asset
@@ -41,9 +41,8 @@ MonoBehaviour:
   _characterSprite: {fileID: 21300000, guid: 0a471cb1f9aef564d84b02f39772cd66, type: 3}
   _prefab: {fileID: 3040210829558697001, guid: 6861ca5fd7922654b851134b76556b08, type: 3}
   _chaLv: 1
-  _chaSkills:
-  - {fileID: 11400000, guid: 60cfb5fa0bc27b14da83722d571124f0, type: 2}
-  _chaActiveSkill: {fileID: 0}
+  _chaSkills: []
+  _chaActiveSkill: {fileID: 11400000, guid: 0e1f6a269f20a784ca12b6ae5669cda8, type: 2}
   _chaPassiveSkill: {fileID: 11400000, guid: 47189edbb54ca18499e51caaa3eb7486, type: 2}
   Beads: 0
   GachaBackground: {fileID: 21300000, guid: 130367da1bf541340908399ee44a9855, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/DRA_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/DRA_Data.asset
@@ -43,6 +43,6 @@ MonoBehaviour:
   _chaLv: 1
   _chaSkills: []
   _chaActiveSkill: {fileID: 0}
-  _chaPassiveSkill: {fileID: 0}
+  _chaPassiveSkill: {fileID: 11400000, guid: d878cb11f5f90e548a5f492a57a47010, type: 2}
   Beads: 0
   GachaBackground: {fileID: 21300000, guid: 47ad4cf55a5e2204d9edec35e0c797f7, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/EMA_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/EMA_Data.asset
@@ -47,6 +47,6 @@ MonoBehaviour:
   _chaLv: 1
   _chaSkills: []
   _chaActiveSkill: {fileID: 0}
-  _chaPassiveSkill: {fileID: 0}
+  _chaPassiveSkill: {fileID: 11400000, guid: d10e51f1b5c6b5a4fb362c7e9535f891, type: 2}
   Beads: 0
   GachaBackground: {fileID: 21300000, guid: 47ad4cf55a5e2204d9edec35e0c797f7, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/GSE_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/GSE_Data.asset
@@ -38,11 +38,11 @@ MonoBehaviour:
     ChaCritDmg: 250
     ChaReg: 20
     ChaMoveSpeed: 0.8
-  _characterSprite: {fileID: 0}
-  _prefab: {fileID: 0}
+  _characterSprite: {fileID: 21300002, guid: 1eaee135ce037439d925cee5e41ce026, type: 3}
+  _prefab: {fileID: 315290852922950502, guid: 8a088c029d820b74d8b77cfb12e77bc1, type: 3}
   _chaLv: 1
   _chaSkills: []
-  _chaActiveSkill: {fileID: 0}
+  _chaActiveSkill: {fileID: 11400000, guid: 431d938b1a2067345b62be8d3e323b3d, type: 2}
   _chaPassiveSkill: {fileID: 11400000, guid: d878cb11f5f90e548a5f492a57a47010, type: 2}
   Beads: 0
   GachaBackground: {fileID: 21300000, guid: 130367da1bf541340908399ee44a9855, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/HSR_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/HSR_Data.asset
@@ -41,9 +41,8 @@ MonoBehaviour:
   _characterSprite: {fileID: 21300000, guid: 68cea2103c29b2a41ad1b9752a8f09a2, type: 3}
   _prefab: {fileID: 6120214078615489053, guid: 3c966d9b67796714f933a92bb77421b0, type: 3}
   _chaLv: 1
-  _chaSkills:
-  - {fileID: 11400000, guid: 60cfb5fa0bc27b14da83722d571124f0, type: 2}
-  _chaActiveSkill: {fileID: 0}
+  _chaSkills: []
+  _chaActiveSkill: {fileID: 11400000, guid: 6589aa72ba5dd374a9e771753e65d224, type: 2}
   _chaPassiveSkill: {fileID: 11400000, guid: d10e51f1b5c6b5a4fb362c7e9535f891, type: 2}
   Beads: 0
   GachaBackground: {fileID: 21300000, guid: 130367da1bf541340908399ee44a9855, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/JHB_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/JHB_Data.asset
@@ -43,6 +43,6 @@ MonoBehaviour:
   _chaLv: 1
   _chaSkills: []
   _chaActiveSkill: {fileID: 0}
-  _chaPassiveSkill: {fileID: 0}
+  _chaPassiveSkill: {fileID: 11400000, guid: 47189edbb54ca18499e51caaa3eb7486, type: 2}
   Beads: 0
   GachaBackground: {fileID: 21300000, guid: 47ad4cf55a5e2204d9edec35e0c797f7, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/SDR_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/SDR_Data.asset
@@ -43,6 +43,6 @@ MonoBehaviour:
   _chaLv: 1
   _chaSkills: []
   _chaActiveSkill: {fileID: 0}
-  _chaPassiveSkill: {fileID: 0}
+  _chaPassiveSkill: {fileID: 11400000, guid: 0e55c03446951384b88a5af133a1832f, type: 2}
   Beads: 0
   GachaBackground: {fileID: 21300000, guid: 47ad4cf55a5e2204d9edec35e0c797f7, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/SIL_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/SIL_Data.asset
@@ -41,9 +41,8 @@ MonoBehaviour:
   _characterSprite: {fileID: 21300000, guid: 4a586d247219bbb448e6b2ce172d7dfd, type: 3}
   _prefab: {fileID: 315290852922950502, guid: fef05c0739b55164ea1677d3f4349296, type: 3}
   _chaLv: 1
-  _chaSkills:
-  - {fileID: 11400000, guid: 60cfb5fa0bc27b14da83722d571124f0, type: 2}
-  _chaActiveSkill: {fileID: 0}
+  _chaSkills: []
+  _chaActiveSkill: {fileID: 11400000, guid: cd0b153ae3b15c645beb75384683886d, type: 2}
   _chaPassiveSkill: {fileID: 11400000, guid: 0e55c03446951384b88a5af133a1832f, type: 2}
   Beads: 0
   GachaBackground: {fileID: 21300000, guid: 130367da1bf541340908399ee44a9855, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/YHY_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/00_Characters/CharactersSOData/YHY_Data.asset
@@ -45,6 +45,6 @@ MonoBehaviour:
   _chaLv: 1
   _chaSkills: []
   _chaActiveSkill: {fileID: 0}
-  _chaPassiveSkill: {fileID: 0}
+  _chaPassiveSkill: {fileID: 11400000, guid: 225cf737d40a09d48b2ddce59168cd9a, type: 2}
   Beads: 0
   GachaBackground: {fileID: 21300000, guid: 47ad4cf55a5e2204d9edec35e0c797f7, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/00_Characters/GSE.prefab
+++ b/Assets/05_KGW_Folder/Prefabs/00_Characters/GSE.prefab
@@ -85,6 +85,7 @@ MonoBehaviour:
   _attackCoolTimer: 0
   _moveDir: {x: 0, y: 0, z: 0}
   _gameSpeed: 0
+  _battleManager: {fileID: 0}
   _characterData: {fileID: 11400000, guid: 53f708173e2eda44480072ad77fcc9bd, type: 2}
   _attackController: {fileID: 6392717553107434659}
   _attackTargets: []
@@ -93,6 +94,9 @@ MonoBehaviour:
   _characterState:
     _chaID: 0
     _chaName: 
+    _chaEnName: 0
+    _chaGrade: 0
+    _chaRole: 0
     _chaLevel: 0
     _chaCurrentHP: 0
     _chaMaxHP: 0
@@ -102,6 +106,8 @@ MonoBehaviour:
     _chaAtkSpeed: 0
     _chaAttack: 0
     _chaArmor: 0
+    _isBarrier: 0
+    _groggyDamage: 0
     _chaAtkIsMelee: 0
     _chaAccuracy: 0
     _chaAvoid: 0
@@ -109,6 +115,8 @@ MonoBehaviour:
     _chaCritDmg: 0
     _chaReg: 0
     _chaMoveSpeed: 0
+    _chaPassiveSkill: {fileID: 11400000, guid: d878cb11f5f90e548a5f492a57a47010, type: 2}
+    _chaActiveSkill: {fileID: 11400000, guid: 431d938b1a2067345b62be8d3e323b3d, type: 2}
     _isManaFull: 0
 --- !u!70 &3348997761910632104
 CapsuleCollider2D:

--- a/Assets/05_KGW_Folder/Prefabs/00_Characters/HSR.prefab
+++ b/Assets/05_KGW_Folder/Prefabs/00_Characters/HSR.prefab
@@ -307,6 +307,7 @@ MonoBehaviour:
   _attackCoolTimer: 0
   _moveDir: {x: 0, y: 0, z: 0}
   _gameSpeed: 0
+  _battleManager: {fileID: 0}
   _characterData: {fileID: 11400000, guid: 9ed735c570481004a8718f1c6026da54, type: 2}
   _attackController: {fileID: 5460872157173418505}
   _attackTargets: []
@@ -327,6 +328,8 @@ MonoBehaviour:
     _chaAtkSpeed: 0
     _chaAttack: 0
     _chaArmor: 0
+    _isBarrier: 0
+    _groggyDamage: 0
     _chaAtkIsMelee: 0
     _chaAccuracy: 0
     _chaAvoid: 0
@@ -334,6 +337,8 @@ MonoBehaviour:
     _chaCritDmg: 0
     _chaReg: 0
     _chaMoveSpeed: 0
+    _chaPassiveSkill: {fileID: 11400000, guid: d10e51f1b5c6b5a4fb362c7e9535f891, type: 2}
+    _chaActiveSkill: {fileID: 11400000, guid: 6589aa72ba5dd374a9e771753e65d224, type: 2}
     _isManaFull: 0
 --- !u!1 &6522983719120484990
 GameObject:

--- a/Assets/05_KGW_Folder/Prefabs/00_Characters/SIL.prefab
+++ b/Assets/05_KGW_Folder/Prefabs/00_Characters/SIL.prefab
@@ -85,6 +85,7 @@ MonoBehaviour:
   _attackCoolTimer: 0
   _moveDir: {x: 0, y: 0, z: 0}
   _gameSpeed: 0
+  _battleManager: {fileID: 0}
   _characterData: {fileID: 11400000, guid: 65f2c3ff647fbb64882a5e1b70abfa2e, type: 2}
   _attackController: {fileID: 6392717553107434659}
   _attackTargets: []
@@ -105,6 +106,8 @@ MonoBehaviour:
     _chaAtkSpeed: 0
     _chaAttack: 0
     _chaArmor: 0
+    _isBarrier: 0
+    _groggyDamage: 0
     _chaAtkIsMelee: 0
     _chaAccuracy: 0
     _chaAvoid: 0
@@ -112,6 +115,8 @@ MonoBehaviour:
     _chaCritDmg: 0
     _chaReg: 0
     _chaMoveSpeed: 0
+    _chaPassiveSkill: {fileID: 11400000, guid: 0e55c03446951384b88a5af133a1832f, type: 2}
+    _chaActiveSkill: {fileID: 11400000, guid: cd0b153ae3b15c645beb75384683886d, type: 2}
     _isManaFull: 0
 --- !u!70 &3348997761910632104
 CapsuleCollider2D:

--- a/Assets/05_KGW_Folder/Prefabs/01_Monsters/NormalMonsters/NormalMonsterSO/FieldMouse_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/01_Monsters/NormalMonsters/NormalMonsterSO/FieldMouse_Data.asset
@@ -28,7 +28,7 @@ MonoBehaviour:
   MonLv: 1
   MonBreak: 0
   BreakGage: 0
-  MonHP: 200
+  MonHP: 1000
   MonHPIncrase: 0.1
   MonAtkSpeed: 0.7
   MonAttack: 10
@@ -40,3 +40,7 @@ MonoBehaviour:
   MonAvoidIncrease: 2
   MonReg: 0
   _prefab: {fileID: 3833880438077353650, guid: bd99561b9ab62854398e1eeab4ea558e, type: 3}
+  _useSkillTime: 0
+  _bossSkill: {fileID: 0}
+  _recallSkills: []
+  _monterRecallSkill: {fileID: 0}

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/AimForTheWound/AimForTheWoundController.cs
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/AimForTheWound/AimForTheWoundController.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 
 public class AimForTheWoundController : MonoBehaviour
 {
+    // 데미지 상승 계산 값 반환
     public float Init(float chance, float value, float damage)
     {
         float skillChance = chance * 0.01f;

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/Cheer/Cheer.prefab
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/Cheer/Cheer.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8792730173350454514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3742037208913130812}
+  - component: {fileID: 8828062543926154861}
+  m_Layer: 0
+  m_Name: Cheer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3742037208913130812
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.983392, y: 0.7338408, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8828062543926154861
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 814ce41008719494db5ead76acced09e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/Cheer/Cheer.prefab.meta
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/Cheer/Cheer.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 38868d4f6bbea424e8c83f6007e052c4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/Cheer/CheerController.cs
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/Cheer/CheerController.cs
@@ -1,18 +1,56 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class CheerController : MonoBehaviour
 {
-    // Start is called before the first frame update
-    void Start()
+    private float _attackUpValue;
+    private float _saveAttack;
+    private float _activeSkillDuration;
+    private bool _isAttackUp;
+    private MyCharacterController _character;
+
+    public void Init(MyCharacterController caster, float value, float duration)
     {
-        
+        _attackUpValue = value;
+        _activeSkillDuration = duration;
+        _saveAttack = caster._characterState._chaAttack;
+        _isAttackUp = false;
+        _character = caster;
+
+        AllCharacterAttackUp();
     }
 
-    // Update is called once per frame
-    void Update()
+    // 전체 캐릭터의 공격력 상승
+    public void AllCharacterAttackUp()
     {
-        
+        if (_isAttackUp) return;
+
+        foreach (var cha in _character._battleManager._characters)
+        {
+            if (!cha._isAlive) continue;
+
+            cha._characterState._chaAttack += _attackUpValue;
+            Debug.Log($"{cha._characterState._chaEnName}의 공격력이 {_attackUpValue}만큼 상승했습니다.");
+        }
+        _isAttackUp = true;
+
+        Invoke(nameof(CharacterAttackReset), _activeSkillDuration);
+
+        // 게임 종료가 되면 상승된 공격력 원복
+        if (_character._battleManager._isGameOver)
+        {
+            CharacterAttackReset();
+        }
+    }
+
+    // 지속시간 후 상승된 공격력 원복 
+    public void CharacterAttackReset()
+    {
+        foreach (var cha in _character._battleManager._characters)
+        {
+            cha._characterState._chaAttack = _saveAttack;
+            Debug.Log($"{cha._characterState._chaEnName}의 공격력이 원상복귀 되었습니다.");
+
+            _isAttackUp = false;
+        }
     }
 }

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/MoraleDecline/MoraleDecline.prefab
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/MoraleDecline/MoraleDecline.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8792730173350454514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3742037208913130812}
+  - component: {fileID: -3177903321646760269}
+  m_Layer: 0
+  m_Name: MoraleDecline
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3742037208913130812
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.983392, y: 0.7338408, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-3177903321646760269
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a31a9944a1154b409968b89ff3a373c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/MoraleDecline/MoraleDecline.prefab.meta
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/MoraleDecline/MoraleDecline.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 32f7ab234e9623f409b35bf804e824a7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/MoraleDecline/MoraleDeclineController.cs
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/MoraleDecline/MoraleDeclineController.cs
@@ -1,18 +1,14 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class MoraleDeclineController : MonoBehaviour
 {
-    // Start is called before the first frame update
-    void Start()
+    // 공격력 감소 계산 값 변환
+    public float Init(float chance, float value)
     {
-        
-    }
+        float skillChance = chance * 0.01f;
+        float attckDownValue = (Random.value < skillChance) ? value : 0f;
+        Destroy(gameObject, 0.1f);
 
-    // Update is called once per frame
-    void Update()
-    {
-        
+        return attckDownValue;
     }
 }

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/PainfulScent/PainfulScent.prefab
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/PainfulScent/PainfulScent.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8792730173350454514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3742037208913130812}
+  - component: {fileID: -688931548403510648}
+  m_Layer: 0
+  m_Name: PainfulScent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3742037208913130812
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.983392, y: 0.7338408, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-688931548403510648
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2d91e8e58f6d58a47a8276aaac15d002, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/PainfulScent/PainfulScent.prefab.meta
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/PainfulScent/PainfulScent.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 41d9ad55b69e9594785e9b5d42b2b812
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/PainfulScent/PainfulScentController.cs
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/PainfulScent/PainfulScentController.cs
@@ -1,18 +1,103 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using static UnityEngine.GraphicsBuffer;
 
 public class PainfulScentController : MonoBehaviour
 {
-    // Start is called before the first frame update
-    void Start()
+    private float _skillDamage;
+    private float _decreaseDownValue;
+    private float _skillAttackHit;
+    private float _skillTick;
+    private float _armorDownValue;
+    private float _saveArmor;
+    private float _activeSkillDuration;
+    private bool _isArmorDown;
+    private MyCharacterController _character;
+    private MonsterController _monster;
+    private Coroutine _attackRoutine;
+    private WaitForSeconds _time;
+
+    public void Init(MyCharacterController caster, MonsterController target, float hit, float damageValue, float armorValue, float duration, float tick)
     {
-        
+        _skillDamage = damageValue * caster._characterState._chaAttack;
+        _skillAttackHit = hit;
+        _skillTick = tick;
+        _armorDownValue = armorValue;
+        _activeSkillDuration = duration;
+        _saveArmor = target._monsterState._monArmor;
+        _isArmorDown = false;
+        _character = caster;
+        _monster = target;
+        _time = new WaitForSeconds(_skillTick);
+
+        AllMonsterAttackSkill();
     }
 
-    // Update is called once per frame
-    void Update()
+    // 전체 몬스터에게 괴로운 향기 공격
+    public void AllMonsterAttackSkill()
     {
-        
+        if (_isArmorDown) return;
+
+        foreach (var mon in _monster._battleManager._monsters)
+        {
+            if (!mon._isAlive) continue;
+
+            // 방어력이 마이너스로 가는걸 방지
+            _decreaseDownValue = Mathf.Min(_saveArmor, _armorDownValue);
+
+            mon._monsterState._monArmor -= _decreaseDownValue;
+            Debug.Log($"{mon._monsterState._monEnName}의 방어력이 {_decreaseDownValue}만큼 하락했습니다.");
+
+            // 데미지 코루틴 시작
+            _attackRoutine = StartCoroutine(MonsterAttackCoroutine(mon));
+        }
+        _isArmorDown = true;
+
+        Invoke(nameof(MonsterArmorReset), _activeSkillDuration);
+
+        // 게임 종료가 되면 감소된 방어력 원복
+        if (_character._battleManager._isGameOver)
+        {
+            MonsterArmorReset();
+            AttackCoroutineStop();
+        }
+    }
+
+    // 지속시간 후 감소된 방어력 원복 
+    public void MonsterArmorReset()
+    {
+        foreach (var mon in _monster._battleManager._monsters)
+        {
+            mon._monsterState._monArmor = _saveArmor;
+            Debug.Log($"{mon._monsterState._monEnName}의 방어력이 원상복귀 되었습니다.");
+
+            _isArmorDown = false;
+        }
+    }
+
+    // 몬스터 스킬 다단 히트 공격 코루틴
+    public IEnumerator MonsterAttackCoroutine(MonsterController mon)
+    {
+        float count = 0;
+
+        while (count < _skillAttackHit)
+        {
+            mon.TakeDamage(_skillDamage);
+            Debug.Log($"{mon._monsterState._monEnName}가 {_skillDamage}의 데미지를 받았습니다.{count}");
+            count++;
+
+            yield return _time;
+        }
+    }
+
+    // 코루틴 정지
+    public void AttackCoroutineStop()
+    {
+        if(_attackRoutine != null)
+        {
+            StopCoroutine( _attackRoutine );
+            _attackRoutine = null;
+        }
     }
 }

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/ProtectiveGrenade/ProtectiveGrenade.prefab
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/ProtectiveGrenade/ProtectiveGrenade.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8792730173350454514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3742037208913130812}
+  - component: {fileID: -7570770566347084705}
+  m_Layer: 0
+  m_Name: ProtectiveGrenade
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3742037208913130812
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.983392, y: 0.7338408, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-7570770566347084705
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad13ee75c8068be4cbbdfe903cc05d8f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/ProtectiveGrenade/ProtectiveGrenade.prefab.meta
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/ProtectiveGrenade/ProtectiveGrenade.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 346537fde4010da49ba98236b66aac38
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/ProtectiveGrenade/ProtectiveGrenadeController.cs
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/ProtectiveGrenade/ProtectiveGrenadeController.cs
@@ -1,18 +1,43 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class ProtectiveGrenadeController : MonoBehaviour
 {
-    // Start is called before the first frame update
-    void Start()
+    private float _skillDamage;
+    private float _saveAttack;
+    private MyCharacterController _character;
+    private MonsterController _monster;
+
+    public void Init(MyCharacterController caster, MonsterController target, float value)
     {
-        
+        _saveAttack = caster._characterState._chaAttack;
+        _skillDamage = _saveAttack * value;
+        _character = caster;
+        _monster = target;
+
+        AllMonsterGrenade();
     }
 
-    // Update is called once per frame
-    void Update()
+    // 전체 몬스터한테 수류탄 투척
+    public void AllMonsterGrenade()
+    {     
+        foreach (var mon in _monster._battleManager._monsters)
+        {
+            if (!mon._isAlive) continue;
+
+            mon.TakeDamage(_skillDamage);
+            Debug.Log($"{mon._monsterState._monEnName}몬스터에게 {_skillDamage}만큼 데미지를 가합니다.");
+        }
+
+        AllCharacterBarrier();
+    }
+
+    // 전체 캐릭터한테 배리어 부여
+    public void AllCharacterBarrier()
     {
-        
+        foreach (var cha in _character._battleManager._characters)
+        {
+            cha._characterState._isBarrier = true;
+            Debug.Log($"{cha._characterState._chaEnName}에게 1회의 배리어를 부여했습니다.");
+        }
     }
 }

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/RegenerativeStrike/RegenerativeStrike.prefab
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/RegenerativeStrike/RegenerativeStrike.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8792730173350454514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3742037208913130812}
+  - component: {fileID: 449035371313145086}
+  m_Layer: 0
+  m_Name: RegenerativeStrike
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3742037208913130812
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.983392, y: 0.7338408, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &449035371313145086
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4c07f874a0bfa8b4d9fffd26cd6ab02a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/RegenerativeStrike/RegenerativeStrike.prefab.meta
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/RegenerativeStrike/RegenerativeStrike.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: afb62200e0b6f05468de468ab653ac86
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/RegenerativeStrike/RegenerativeStrikeContoller.cs
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/RegenerativeStrike/RegenerativeStrikeContoller.cs
@@ -7,7 +7,7 @@ public class RegenerativeStrikeContoller : MonoBehaviour
     public float Init(float chance, float value, float damage)
     {
         float skillChance = chance * 0.01f;
-        float skillValue = (Random.value < skillChance) ? value : 1f;
+        float skillValue = (Random.value < skillChance) ? value : 0f;
         Destroy(gameObject, 0.1f);
 
         return damage * skillValue;

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/Vanguard/Vanguard.prefab
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/Vanguard/Vanguard.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8792730173350454514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3742037208913130812}
+  - component: {fileID: 6792696499271947619}
+  m_Layer: 0
+  m_Name: Vanguard
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3742037208913130812
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.983392, y: 0.7338408, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6792696499271947619
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 13eefbb35f842824aa7395f252a0c47c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/Vanguard/Vanguard.prefab.meta
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/Vanguard/Vanguard.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6e3eba291fade8043b99a824641233b4
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/Vanguard/VanguardController.cs
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/Vanguard/VanguardController.cs
@@ -1,18 +1,13 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class VanguardController : MonoBehaviour
 {
-    // Start is called before the first frame update
-    void Start()
+    // 방어력 상승값 반환
+    public float Init(float value)
     {
-        
-    }
+        float armorUp = value;
+        Destroy(gameObject, 0.1f);
 
-    // Update is called once per frame
-    void Update()
-    {
-        
+        return armorUp;
     }
 }

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WaveOfSteel/WaveOfSteel.prefab
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WaveOfSteel/WaveOfSteel.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8792730173350454514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3742037208913130812}
+  - component: {fileID: -7683083479709023869}
+  m_Layer: 0
+  m_Name: WaveOfSteel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3742037208913130812
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.983392, y: 0.7338408, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-7683083479709023869
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d8f816c9d83ddb646a9c8a4ca1db0cd2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WaveOfSteel/WaveOfSteel.prefab.meta
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WaveOfSteel/WaveOfSteel.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 77cf2f03e94412f4396a146ec41d3c1f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WaveOfSteel/WaveOfSteelController.cs
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WaveOfSteel/WaveOfSteelController.cs
@@ -1,18 +1,14 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class WaveOfSteelController : MonoBehaviour
 {
-    // Start is called before the first frame update
-    void Start()
+    // 전체 공격력 계산 반환
+    public float Init(float chance, float value, float damage)
     {
-        
-    }
+        float skillChance = chance * 0.01f;
+        float skillValue = (Random.value < skillChance) ? value : 0f;
+        Destroy(gameObject, 0.1f);
 
-    // Update is called once per frame
-    void Update()
-    {
-        
+        return damage * skillValue;
     }
 }

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WolfSlash/WolfSlash.prefab
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WolfSlash/WolfSlash.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8792730173350454514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3742037208913130812}
+  - component: {fileID: -4628582380494033448}
+  m_Layer: 0
+  m_Name: WolfSlash
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3742037208913130812
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.983392, y: 0.7338408, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-4628582380494033448
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 82d183e1fbfe9dc4998c3a0ccddb945e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WolfSlash/WolfSlash.prefab.meta
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WolfSlash/WolfSlash.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c2a07cbe5c197024285d4db2c20b11fd
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WolfSlash/WolfSlashController.cs
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WolfSlash/WolfSlashController.cs
@@ -4,15 +4,69 @@ using UnityEngine;
 
 public class WolfSlashController : MonoBehaviour
 {
-    // Start is called before the first frame update
-    void Start()
+    private float _skillDamage;
+    private float _skillAttackHit;
+    private float _skillTick;
+    private MyCharacterController _character;
+    private MonsterController _monster;
+    private Coroutine _attackRoutine;
+    private WaitForSeconds _time;
+
+    public void Init(MyCharacterController caster, MonsterController target, float hit, float damageValue, float armorValue, float tick)
     {
-        
+        _skillDamage = damageValue * caster._characterState._chaAttack;
+        _skillAttackHit = hit;
+        _skillTick = tick;
+        _character = caster;
+        _monster = target;
+        _time = new WaitForSeconds(_skillTick);
+
+        AllMonsterWolfSlash();
     }
 
-    // Update is called once per frame
-    void Update()
+    // 전체 몬스터에게 늑대 베기 사용
+    public void AllMonsterWolfSlash()
     {
-        
+        foreach (var mon in _monster._battleManager._monsters)
+        {
+            if (!mon._isAlive) continue;
+            // 데미지 코루틴 시작
+            _attackRoutine = StartCoroutine(MonsterAttackCoroutine(mon));
+        }
+
+        // 게임 종료가 되면 감소된 방어력 원복
+        if (_character._battleManager._isGameOver)
+        {
+            AttackCoroutineStop();
+        }
+    }
+    
+    // 몬스터 스킬 다단 히트 공격 코루틴
+    public IEnumerator MonsterAttackCoroutine(MonsterController mon)
+    {
+        float count = 0;
+
+        while (count < _skillAttackHit)
+        {
+            mon.TakeDamage(_skillDamage);
+            Debug.Log($"{mon._monsterState._monEnName}가 {_skillDamage}의 데미지를 받았습니다.{count}");
+            count++;
+
+            // 공격한 만큼 캐릭터의 체력 회복
+            _character.CharacterHealApply(_skillDamage);
+            Debug.Log($"{_character._characterState._chaEnName}의 체력이 {_skillDamage}만큼 회복됬습니다.");
+
+            yield return _time;
+        }
+    }
+
+    // 코루틴 정지
+    public void AttackCoroutineStop()
+    {
+        if (_attackRoutine != null)
+        {
+            StopCoroutine(_attackRoutine);
+            _attackRoutine = null;
+        }
     }
 }

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WrathOfTheGuardian/WrathOfTheGuardian.prefab
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WrathOfTheGuardian/WrathOfTheGuardian.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8792730173350454514
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3742037208913130812}
+  - component: {fileID: 6570734812645491652}
+  m_Layer: 0
+  m_Name: WrathOfTheGuardian
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3742037208913130812
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -2.983392, y: 0.7338408, z: 0}
+  m_LocalScale: {x: 2, y: 2, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &6570734812645491652
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8792730173350454514}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e87abec628c98ad469bd2480c7e309ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WrathOfTheGuardian/WrathOfTheGuardian.prefab.meta
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WrathOfTheGuardian/WrathOfTheGuardian.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ef3fef9e16e18ee4e93fd9850795f051
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WrathOfTheGuardian/WrathOfTheGuardianController.cs
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsData/WrathOfTheGuardian/WrathOfTheGuardianController.cs
@@ -1,18 +1,65 @@
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 public class WrathOfTheGuardianController : MonoBehaviour
 {
-    // Start is called before the first frame update
-    void Start()
+    private float _skillDamage;
+    private float _skillAttackHit;
+    private float _skillTick;
+    private MonsterController _monster;
+    private MyCharacterController _character;
+    private Coroutine _attackRoutine;
+    private WaitForSeconds _time;
+
+    public void Init(MyCharacterController caster, MonsterController target, float hit, float damageValue, float tick)
     {
-        
+        _skillDamage = damageValue * caster._characterState._chaAttack;
+        _skillAttackHit = hit;
+        _skillTick = tick;
+        _character = caster;
+        _monster = target;
+        _time = new WaitForSeconds(_skillTick);
+
+        SingleMonsterAttack();
     }
 
-    // Update is called once per frame
-    void Update()
+    // 단일 몬스터에게 스킬 공격
+    public void SingleMonsterAttack()
     {
-        
+        if (!_monster._isAlive) return;
+
+        // 데미지 코루틴 시작
+        _attackRoutine = StartCoroutine(MonsterAttackCoroutine(_monster));
+
+        // 게임 종료가 되면 공격 코루틴 정지
+        if (_character._battleManager._isGameOver)
+        {
+            AttackCoroutineStop();
+        }
+    }
+
+    // 몬스터 스킬 다단 히트 공격 코루틴
+    public IEnumerator MonsterAttackCoroutine(MonsterController mon)
+    {
+        float count = 0;
+
+        while (count < _skillAttackHit)
+        {
+            mon.TakeDamage(_skillDamage);
+            Debug.Log($"{mon._monsterState._monEnName}가 {_skillDamage}의 데미지를 받았습니다.{count}");
+            count++;
+
+            yield return _time;
+        }
+    }
+
+    // 코루틴 정지
+    public void AttackCoroutineStop()
+    {
+        if (_attackRoutine != null)
+        {
+            StopCoroutine(_attackRoutine);
+            _attackRoutine = null;
+        }
     }
 }

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/Cheer_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/Cheer_Data.asset
@@ -26,3 +26,4 @@ MonoBehaviour:
   _chaEffectValue: 30
   _chaSkillDescription: "\uBAA8\uB4E0 \uC544\uAD70\uC758 \uACF5\uACA9\uB825\uC744
     <chaEffectValue>% \uB9CC\uD07C \uC0C1\uC2B9\uC2DC\uD0A8\uB2E4.\r"
+  _chaSkillPrefab: {fileID: 8792730173350454514, guid: 38868d4f6bbea424e8c83f6007e052c4, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/MoraleDecline_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/MoraleDecline_Data.asset
@@ -26,3 +26,4 @@ MonoBehaviour:
   _chaEffectValue: 20
   _chaSkillDescription: "\uACF5\uACA9 \uC2DC <chaSkillChance>%\uB85C \uC801\uC758
     \uACF5\uACA9\uB825\uC744 <chaEffectValue> \uB9CC\uD07C \uAC10\uC18C \uC2DC\uD0A8\uB2E4.\r"
+  _chaSkillPrefab: {fileID: 8792730173350454514, guid: 32f7ab234e9623f409b35bf804e824a7, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/PainfulScent_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/PainfulScent_Data.asset
@@ -28,3 +28,4 @@ MonoBehaviour:
     <chaAttack>*<chaSkillValue> x <chaSkillHit>\uC758 \uD53C\uD574\uB97C \uC785\uD788\uACE0,
     \uBAA8\uB4E0 \uC801\uC758 \uBC29\uC5B4\uB825\uC744  <chaEffectValue> \uB9CC\uD07C
     \uAC10\uC18C \uC2DC\uD0A8\uB2E4.\r"
+  _chaSkillPrefab: {fileID: 8792730173350454514, guid: 41d9ad55b69e9594785e9b5d42b2b812, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/ProtectiveGrenade_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/ProtectiveGrenade_Data.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
   _chaSkillDescription: "\uBAA8\uB4E0 \uC801\uC5D0\uAC8C \uC218\uB958\uD0C4\uC744
     \uB358\uC838 <chaAttack>*<chaSkillValue>\uC758 \uD53C\uD574\uB97C \uC785\uD788\uACE0,
     \uBAA8\uB4E0 \uC544\uAD70\uC5D0\uAC8C \uBC30\uB9AC\uC5B4 1\uD68C\uB97C \uBD80\uC5EC\uD55C\uB2E4.\r"
+  _chaSkillPrefab: {fileID: 8792730173350454514, guid: 346537fde4010da49ba98236b66aac38, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/RegenerativeStrike_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/RegenerativeStrike_Data.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
   _chaSkillDescription: "\uACF5\uACA9 \uC2DC <chaSkillChance>%\uB85C  \uBAA8\uB4E0
     \uC544\uAD70\uC758 \uCCB4\uB825\uC744 <chaAttack>*<chaSkillValue> \uD68C\uBCF5
     \uC2DC\uD0A8\uB2E4.\r"
+  _chaSkillPrefab: {fileID: 8792730173350454514, guid: afb62200e0b6f05468de468ab653ac86, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/Vanguard_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/Vanguard_Data.asset
@@ -26,3 +26,4 @@ MonoBehaviour:
   _chaEffectValue: 30
   _chaSkillDescription: "\uBAA8\uB4E0 \uC544\uAD70\uC758 \uBC29\uC5B4\uB825\uC744
     <chaEffectValue> \uB9CC\uD07C \uC0C1\uC2B9\uC2DC\uD0A8\uB2E4.\r"
+  _chaSkillPrefab: {fileID: 8792730173350454514, guid: 6e3eba291fade8043b99a824641233b4, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/WaveOfSteel_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/WaveOfSteel_Data.asset
@@ -26,3 +26,4 @@ MonoBehaviour:
   _chaEffectValue: -1
   _chaSkillDescription: "\uACF5\uACA9 \uC2DC <chaSkillChance>%\uB85C \uBAA8\uB4E0
     \uC801\uC5D0\uAC8C <chaAttack>*<chaSkillValue>\uC758 \uD53C\uD574\uB97C \uC785\uD78C\uB2E4.\r"
+  _chaSkillPrefab: {fileID: 8792730173350454514, guid: 77cf2f03e94412f4396a146ec41d3c1f, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/WolfSlash_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/WolfSlash_Data.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
   _chaSkillDescription: "\uAC80\uC744 \uD06C\uAC8C \uD718\uB458\uB7EC \uBAA8\uB4E0
     \uC801\uC5D0\uAC8C <chaAttack>*<chaSkillValue> x <chaSkillHit>\uC758 \uD53C\uD574\uB97C
     \uC785\uD788\uACE0, \uC785\uD78C \uD53C\uD574\uB7C9 \uB9CC\uD07C HP\uB97C \uD68C\uBCF5\uD55C\uB2E4.\r"
+  _chaSkillPrefab: {fileID: 8792730173350454514, guid: c2a07cbe5c197024285d4db2c20b11fd, type: 3}

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/WrathOfTheGuardian_Data.asset
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/CharacterSkills/SkillsSOData/WrathOfTheGuardian_Data.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
   _chaSkillDescription: "\uC218\uD638\uB839\uC744 \uBD88\uB7EC\uB0B4\uC5B4 \uD604\uC7AC
     \uACF5\uACA9 \uC911\uC778 \uB300\uC0C1\uC5D0\uAC8C <chaAttack>*<chaSkillValue>
     x <chaSkillHit>\uC758 \uAC15\uB825\uD55C \uD53C\uD574\uB97C \uC785\uD78C\uB2E4."
+  _chaSkillPrefab: {fileID: 8792730173350454514, guid: ef3fef9e16e18ee4e93fd9850795f051, type: 3}

--- a/Assets/05_KGW_Folder/Scripts/Characters/MyCharacterController.cs
+++ b/Assets/05_KGW_Folder/Scripts/Characters/MyCharacterController.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using SDW;
-using TableForge.Demo;
+using UnityEditor.Experimental.GraphView;
 using UnityEngine;
 
 public class MyCharacterController : UnitBaseData
@@ -44,12 +44,12 @@ public class MyCharacterController : UnitBaseData
     // 캐릭터 생성 초기화
     protected override void Init()
     {
+        _characterState._chaLevel = _characterData._chaLv;
         _characterState._chaID = _characterData._chaBaseData.ChaID;
         _characterState._chaName = _characterData._chaBaseData.ChaName;
         _characterState._chaEnName = _characterData._chaBaseData.ChaEnName;
         _characterState._chaGrade = _characterData._chaBaseData.ChaGrade;
         _characterState._chaRole = _characterData._chaBaseData.ChaRole;
-        _characterState._chaLevel = _characterData._chaLv;
         _characterState._chaCurrentHP = _characterData._chaBaseData.ChaHP;
         _characterState._chaMaxHP = _characterData._chaBaseData.ChaHP;
         _characterState._chaCurrentMP = 0f;
@@ -66,7 +66,7 @@ public class MyCharacterController : UnitBaseData
         _characterState._chaReg = _characterData._chaTypeData.ChaReg;
         _characterState._chaMoveSpeed = _characterData._chaTypeData.ChaMoveSpeed;
         _characterState._isBarrier = false;
-        _characterState._groggyDamage = _characterState._chaAttack;
+        _characterState._groggyDamage = 0f;
         _characterState._chaPassiveSkill = _characterData._chaPassiveSkill;
         _moveDir = Vector3.right;
         _isAlive = true;
@@ -76,9 +76,11 @@ public class MyCharacterController : UnitBaseData
         OnMpChange?.Invoke(_characterState._chaCurrentMP / _characterState._chaMaxMP);
         // 타임오버에 대한 캐릭터 삭제 이벤트 구독
         _battleUI.OnTimeOver += TimeDeath;
+
         _attackCoolTimer = _characterState._chaAtkSpeed;
 
         _manaChangeValue = _characterState._chaMPRecovery;
+
         // 마나 충전 
         ManaRecovery();
     }
@@ -87,7 +89,6 @@ public class MyCharacterController : UnitBaseData
     {
         // 타임오버에 대한 캐릭터 삭제 이벤트 구독 해제
         _battleUI.OnTimeOver -= TimeDeath;
-
     }
 
     // 캐릭터 이동
@@ -164,12 +165,24 @@ public class MyCharacterController : UnitBaseData
                 }
                 Debug.Log($"{passiveDamage}의 데미지로 적을 공격합니다.");
 
-                // 캐릭터의 데미지로 몬스터에 주기
-                _attackTarget.TakeDamage(passiveDamage);
+                // 체력회복 패시브 스킬
+                HealHpPassive();
+                // 공격력 감소 패시브 확인
+                AttackDownPassiveCheck();
+                // 몬스터 전체 공격 패시브 스킬
+                AllMonsterDamagePassive();
 
-                if (_attackTarget != null)
+                // 몬스터가 살아있으면 공격
+                if (_attackTarget._isAlive)
                 {
-                    _attackTarget.AttackTargetChange(_chaCon);
+                    // 캐릭터의 데미지로 몬스터에 주기
+                    _attackTarget.TakeDamage(passiveDamage);
+
+                    if(_attackTarget != null)
+                    {
+                        // 몬스터의 공격 타겟 전환
+                        _attackTarget.AttackTargetChange(_chaCon);
+                    }
                 }
 
                 _isAttack = true;
@@ -187,10 +200,11 @@ public class MyCharacterController : UnitBaseData
     // 데미지를 받음
     public override void TakeDamage(float damage)
     {
-        // 베리어 상태일때는 공격을 무시함.
+        // 배리어 상태일때는 공격을 무시함.
         if (_characterState._isBarrier)
         {
             _characterState._isBarrier = false;
+            Debug.Log($"{_characterState._chaEnName}의 배리어가 사용되었습니다.");
             return;
         }
 
@@ -244,28 +258,101 @@ public class MyCharacterController : UnitBaseData
             // 유물 효과 적용
             OnRelicEffect?.Invoke();
 
-            // 보유한 스킬을 순회
-            foreach (var skill in _characterData._chaSkills)
-            {
-                Debug.Log("스킬 사용");
-                // 스킬 사용
-                skill.UseSkill(_chaCon, _attackTarget);
+            // 스킬 사용
+            _characterState._chaActiveSkill.UseSkill(_chaCon, _characterData._chaActiveSkill, _attackTarget);
 
-                // 마나 초기화
-                _characterState._chaCurrentMP = 0f;
-                // 마나 변화에 대한 이벤트 호출
-                OnMpChange?.Invoke(Mathf.Clamp01(_characterState._chaCurrentMP / _characterState._chaMaxMP));
-
-                // 마나 제로
-                _characterState._isManaFull = false;
-                // 스킬 사용 모드 전환 이벤트 호출
-                OnSkillModeChange?.Invoke(_characterState._isManaFull);
-
-                // 마나 회복
-                ManaRecovery();
-            }
+            CharacterManaState();
         }
     }
+
+    #region 캐릭터의 패시브 스킬 동작 메서드
+    // 체력 회복 패시브 스킬
+    public void HealHpPassive()
+    {
+        float attackDamage = _characterState._chaAttack;
+        float healValue = 0f;
+
+        // 체력 회복 패시브 스킬이 있는지 확인
+        if (_characterData._chaPassiveSkill._chaSkillEnName == CharacterSkillEnName.RegenerativeStrike)
+        {
+            healValue = _characterData._chaPassiveSkill.UsePassiveSkill(_chaCon, _characterData._chaPassiveSkill, attackDamage);
+
+            // 회복량이 0이면 넘어감
+            if (healValue == 0f) return;
+
+            Debug.Log($"전체 캐릭터의 체력이 {healValue}만큼 회복되었습니다.");
+
+            _battleManager.AllCharacterHeal(healValue);
+        }
+    }
+
+    // 전체 캐릭터 회복
+    public void CharacterHealApply(float healValue)
+    {
+        _characterState._chaCurrentHP = Mathf.Min(_characterState._chaCurrentHP + healValue, _characterState._chaMaxHP);
+
+        // 체력 변화에 대한 이벤트 호출
+        OnHpChange?.Invoke(Mathf.Clamp01(_characterState._chaCurrentHP / _characterState._chaMaxHP));
+    }
+
+    // 아머 상승 패시브 스킬
+    public void ArmorUpPassive()
+    {
+        if (_characterData._chaPassiveSkill._chaSkillEnName == CharacterSkillEnName.Vanguard)
+        {
+            float chaAamor = _characterState._chaArmor;
+            float upValue = _characterData._chaPassiveSkill.UsePassiveSkill(_chaCon, _characterData._chaPassiveSkill, chaAamor);
+
+            Debug.Log($"전체 캐릭터의 방어력이 {upValue}만큼 상승했습니다.");
+
+            // 전체 캐릭터 아머 상승
+            _battleManager.AllCharacterArmorUp(upValue);
+        }
+    }
+
+    // 전체 아머 상승
+    public void AllCharacterArmorUpApply(float upValue)
+    {
+        _characterState._chaArmor += upValue;
+    }
+
+    // 공격력 다운 패시브 확인
+    public void AttackDownPassiveCheck()
+    {
+        // 사기 저하 패시브 스킬이 있는지 확인
+        if(_characterData._chaPassiveSkill._chaSkillEnName == CharacterSkillEnName.MoraleDecline)
+        {
+            float saveAttack = _attackTarget._monsterState._monAttack;
+            float attackDownValue = _characterData._chaPassiveSkill.UsePassiveSkill(_chaCon, _characterState._chaPassiveSkill, _characterState._chaPassiveSkill._chaEffectValue);
+
+            // 감소할 공격력이 0이면 넘어감
+            if (attackDownValue == 0f) return;
+
+            // 사기 저하 패시브 스킬
+            _attackTarget.AttackDownPassive(saveAttack, attackDownValue);
+        }
+    }
+
+    // 몬스터 전체 공격 패시브 스킬
+    public void AllMonsterDamagePassive()
+    {
+        float attackDamage = _characterState._chaAttack;
+        float allAttackDamage = 0f;
+
+        // 체력 회복 패시브 스킬이 있는지 확인
+        if (_characterData._chaPassiveSkill._chaSkillEnName == CharacterSkillEnName.WaveOfSteel)
+        {
+            allAttackDamage = _characterData._chaPassiveSkill.UsePassiveSkill(_chaCon, _characterData._chaPassiveSkill, attackDamage);
+
+            // 데미지가 0이면 넘어감
+            if (allAttackDamage == 0f) return;
+
+            Debug.Log($"전체 몬스터에게 {allAttackDamage}만큼 데미지를 줍니다.");
+
+            _battleManager.AllMonsterDamage(allAttackDamage);
+        }
+    }
+    #endregion
 
     // 캐릭터 사망
     protected override void Death()
@@ -286,6 +373,23 @@ public class MyCharacterController : UnitBaseData
         {
             base.Death();
         }
+    }
+
+    // 캐릭터 마나 상태 확인
+    public void CharacterManaState()
+    {
+        // 마나 초기화
+        _characterState._chaCurrentMP = 0f;
+        // 마나 변화에 대한 이벤트 호출
+        OnMpChange?.Invoke(Mathf.Clamp01(_characterState._chaCurrentMP / _characterState._chaMaxMP));
+
+        // 마나 제로
+        _characterState._isManaFull = false;
+        // 스킬 사용 모드 전환 이벤트 호출
+        OnSkillModeChange?.Invoke(_characterState._isManaFull);
+
+        // 마나 회복
+        ManaRecovery();
     }
 
     // 마나 회복

--- a/Assets/05_KGW_Folder/Scripts/IntegratedScripts/UnitBaseData.cs
+++ b/Assets/05_KGW_Folder/Scripts/IntegratedScripts/UnitBaseData.cs
@@ -19,7 +19,7 @@ public abstract class UnitBaseData : MonoBehaviour
     public int _gameSpeed; // 게임 속도
 
     private Coroutine _knockbackRoutine;
-    protected BattleManager _battleManager;
+    public BattleManager _battleManager;
     protected BattleUI _battleUI;
     protected CharacterDataSO _chaData;
     protected MonsterDataSO _monData;

--- a/Assets/05_KGW_Folder/Scripts/Manager/Battle/BattleManager.cs
+++ b/Assets/05_KGW_Folder/Scripts/Manager/Battle/BattleManager.cs
@@ -47,6 +47,7 @@ public class BattleManager : MonoBehaviour
 
     public BattleUI _battleUI;
     //private List<CharacterDataSO> _selectCharacters;
+    Coroutine _armorRoutine;
     public int _monsterCount;
     public int _characterCount;
     public bool _isClear;
@@ -149,6 +150,8 @@ public class BattleManager : MonoBehaviour
 
         // 생성된 캐릭터 수 저장
         _characterCount = _characters.Count;
+
+        _armorRoutine = StartCoroutine(ApplyArmorPassiveCoroutine());
     }
 
     // 몬스터 스폰
@@ -293,4 +296,68 @@ public class BattleManager : MonoBehaviour
             OnGameResult?.Invoke(_isClear);
         }
     }
+
+    #region 캐릭터의 액티브 스킬 동작
+
+    #endregion
+    #region 캐릭터의 패시브 스킬 동작 
+    // 캐릭터 전체 체력 회복
+    public void AllCharacterHeal(float healValue)
+    {
+        foreach(var cha in _characters)
+        {
+            if(cha._isAlive) cha.CharacterHealApply(healValue);
+        }
+    }
+
+    // 아머 상승 패시브 유/무 확인
+    public void ArmorUpPassiveCheck()
+    {
+        foreach (var cha in _characters)
+        {
+            // 전투에 참가한 캐릭터에 아머 상승 패시브를 가지고 있는지 체크
+            if (cha._characterState._chaPassiveSkill._chaSkillEnName == CharacterSkillEnName.Vanguard)
+            {
+                // 아머 상승 패시브를 가지고 있으면 실행
+                cha.ArmorUpPassive();
+                break;
+            }
+        }
+    }
+
+    // 캐릭터 전체 아머 상승
+    public void AllCharacterArmorUp(float upValue)
+    {
+        foreach(var cha in _characters)
+        {
+            // 전체 캐릭터 아머 상승 적용
+            cha.AllCharacterArmorUpApply(upValue);
+        }
+    }
+
+    // 방어력 상승 코루틴
+    private IEnumerator ApplyArmorPassiveCoroutine()
+    {
+        yield return null; // 모든 캐릭터가 생성 후 초기화가 끝날 때까지 대기
+
+        ArmorUpPassiveCheck(); // 아머 상승 패시브 체크
+    }
+
+    // 몬스터 전체 공격
+    public void AllMonsterDamage(float damageValue)
+    {
+        foreach(var mon in _monsters)
+        {
+            if(mon._isAlive)
+            {
+                Debug.Log($"{mon._monsterState._monEnName}가 {damageValue}의 공격받음");
+
+                if(mon != null)
+                {
+                    mon.TakeDamage(damageValue);
+                }
+            }
+        }
+    }
+    #endregion
 }

--- a/Assets/05_KGW_Folder/Scripts/Monsters/MonsterController.cs
+++ b/Assets/05_KGW_Folder/Scripts/Monsters/MonsterController.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using SDW;
-using TableForge.Demo;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -23,8 +22,10 @@ public class MonsterController : UnitBaseData
 
     public bool _isDetect;
     public bool _isFirst;
+    public bool _isApplyPassive;
     private RecallPointProvider _recallPointProvider;
     private MonsterController _monster;
+    private float decreaseAttackValue;
 
     // 체력 절반 이벤트
     public event Action OnHalfHp;
@@ -68,6 +69,7 @@ public class MonsterController : UnitBaseData
 
         _moveDir = Vector3.left;
         _isAlive = true;
+        _isApplyPassive = false;
         _monData = _monsterData;
         _attackCoolTimer = _monsterState._monAtkSpeed;
         _recallPointProvider = GetComponent<RecallPointProvider>();
@@ -293,5 +295,41 @@ public class MonsterController : UnitBaseData
 
         // 공격 대상 전환
         _attackTarget = chaData;
+
     }
+
+    #region 캐릭터의 패시브 스킬 효과
+    // 사기 저하 패시브 스킬
+    public void AttackDownPassive(float saveAttack, float attackDownValue)
+    {
+        // 지속 시간 중 중복 적용 방지
+        if (!_isApplyPassive)
+        {
+            Debug.Log($"{_monsterState._monEnName}의 공격력이 {attackDownValue}만큼 감소했습니다.");
+
+            // 공격력이 마이너스로 가는걸 방지
+            decreaseAttackValue = MathF.Min(saveAttack, attackDownValue);
+
+            Debug.Log($"실제로 {_monsterState._monEnName}의 공격력이 {decreaseAttackValue}만큼 감소했습니다.");
+
+            // 공격한 몬스터의 공격력 감소
+            _monsterState._monAttack -= decreaseAttackValue;
+            _isApplyPassive = true;
+
+            // 사기 저하 원복
+            Invoke(nameof(AttackDownPassiveRestoration), 3f);
+        }
+    }
+
+    // 사기 저하 효과 원복
+    private void AttackDownPassiveRestoration()
+    {
+        if (_isApplyPassive)
+        {
+            _isApplyPassive = false;
+            _monsterState._monAttack += decreaseAttackValue;
+            Debug.Log($"지속시간이 지나서 {_monsterState._monEnName}의 공격력이 {decreaseAttackValue}만큼 증가했습니다.");
+        }
+    }
+    #endregion
 }

--- a/Assets/05_KGW_Folder/Scripts/Skills/DataSO/CharacterSkillDataSO.cs
+++ b/Assets/05_KGW_Folder/Scripts/Skills/DataSO/CharacterSkillDataSO.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using SDW;
 using UnityEngine;
 
@@ -26,9 +25,29 @@ public class CharacterSkillDataSO : ScriptableObject
     public GameObject _chaSkillPrefab; // 스킬 프리팹
 
     // 스킬 사용 함수
-    public virtual void UseSkill(MyCharacterController caster, MonoBehaviour target)
+    public virtual void UseSkill(MyCharacterController caster, CharacterSkillDataSO skill, MonsterController target)
     {
-        // 캐릭터의 공격 스킬 사용하려면 해당 함수 사용
+        switch (skill._chaSkillEnName)
+        {
+            case CharacterSkillEnName.Cheer:   // 응원
+                skill.UseCheer(caster);
+                break;
+            case CharacterSkillEnName.ProtectiveGrenade:    // 보호 수류탄
+                skill.UseProtectiveGrenade(caster, target);
+                break;
+            case CharacterSkillEnName.PainfulScent:    // 괴로운 향기
+                skill.UsePainfulScent(caster, target);
+                break;
+            case CharacterSkillEnName.WolfSlash:  // 늑대 베기
+                skill.UseWolfSlash(caster, target);
+                break;
+            case CharacterSkillEnName.WrathOfTheGuardian:   // 수호령의 분노
+                skill.UseWrathOfTheGuardian(caster, target);
+                break;
+            default:
+                Debug.Log("스킬이 없음");
+                break;
+        }
     }
 
     // 패시브 스킬 사용 함수
@@ -38,14 +57,14 @@ public class CharacterSkillDataSO : ScriptableObject
         {           
             case CharacterSkillEnName.RegenerativeStrike:   // 재생의 일격
                 return UseRegenerativeStrike(caster, value);
-            case CharacterSkillEnName.Vanguard:
+            case CharacterSkillEnName.Vanguard: // 선봉장
                 return UseVanguard(caster, value);
-            case CharacterSkillEnName.MoraleDecline:
+            case CharacterSkillEnName.MoraleDecline:    // 사기 저하
                 return UseMoraleDecline(caster, value);
-            case CharacterSkillEnName.WaveOfSteel:
+            case CharacterSkillEnName.WaveOfSteel:  // 강철의 파동
                 return UseWaveOfSteel(caster, value);
-            case CharacterSkillEnName.AimForTheWound:
-                return UseAimForTheWound(caster, value);    // 상처 조준
+            case CharacterSkillEnName.AimForTheWound:   // 상처 조준
+                return UseAimForTheWound(caster, value);    
             default:
                 Debug.Log("스킬이 없음");
                 return value;
@@ -70,6 +89,59 @@ public class CharacterSkillDataSO : ScriptableObject
         _chaSkillDescription = skillFileData.ChaSkillDescription;
     }
 
+    #region 캐릭터의 액티브 스킬
+    // 응원 액티브 스킬
+    public void UseCheer(MyCharacterController caster)
+    {
+        Debug.Log($"{caster._characterState._chaEnName} : 응원 액티브 발동");
+        GameObject cheer = Instantiate(_chaSkillPrefab, caster.transform.position, caster.transform.rotation);
+        CheerController skillCon = cheer.GetComponent<CheerController>();
+
+        skillCon.Init(caster, _chaSkillValue, _chaSkillDuration);
+    }
+
+    // 보호 수류탄 액티브 스킬
+    public void UseProtectiveGrenade(MyCharacterController caster, MonsterController target)
+    {
+        Debug.Log($"{caster._characterState._chaEnName} : 보호 수류탄 액티브 발동");
+        GameObject protectiveGrenade = Instantiate(_chaSkillPrefab, caster.transform.position, caster.transform.rotation);
+        ProtectiveGrenadeController skillCon = protectiveGrenade.GetComponent<ProtectiveGrenadeController>();
+
+        skillCon.Init(caster, target, _chaSkillValue);
+    }
+
+    // 괴로운 향기 액티브 스킬
+    public void UsePainfulScent(MyCharacterController caster, MonsterController target)
+    {
+        Debug.Log($"{caster._characterState._chaEnName} : 괴로운 향기 액티브 발동");
+        GameObject painfulScent = Instantiate(_chaSkillPrefab, caster.transform.position, caster.transform.rotation);
+        PainfulScentController skillCon = painfulScent.GetComponent<PainfulScentController>();
+
+        skillCon.Init(caster, target, _chaSkillHit, _chaSkillValue, _chaEffectValue, _chaSkillDuration, _chaSkillTick);
+    }
+
+    // 늑대 베기 액티브 스킬
+    public void UseWolfSlash(MyCharacterController caster, MonsterController target)
+    {
+        Debug.Log($"{caster._characterState._chaEnName} : 늑대 베기 액티브 발동");
+        GameObject wolfSlash = Instantiate(_chaSkillPrefab, caster.transform.position, caster.transform.rotation);
+        WolfSlashController skillCon = wolfSlash.GetComponent<WolfSlashController>();
+
+        skillCon.Init(caster, target, _chaSkillHit, _chaSkillValue, _chaEffectValue, _chaSkillTick);
+    }
+
+    // 수호령의 분노 액티브 스킬
+    public void UseWrathOfTheGuardian(MyCharacterController caster, MonsterController target)
+    {
+        Debug.Log($"{caster._characterState._chaEnName} : 수호령의 분노 액티브 발동");
+        GameObject wrathOfTheGuardian = Instantiate(_chaSkillPrefab, caster.transform.position, caster.transform.rotation);
+        WrathOfTheGuardianController skillCon = wrathOfTheGuardian.GetComponent<WrathOfTheGuardianController>();
+
+        skillCon.Init(caster, target, _chaSkillHit, _chaSkillValue, _chaSkillTick);
+    }
+    #endregion
+
+    #region 캐릭터의 패시브 스킬
     // 재생의 일격 패시브 스킬
     public float UseRegenerativeStrike(MyCharacterController caster, float value)
     {
@@ -84,28 +156,28 @@ public class CharacterSkillDataSO : ScriptableObject
     public float UseVanguard(MyCharacterController caster, float value)
     {
         Debug.Log($"{caster._characterState._chaEnName} : 선봉장 패시브 발동");
-        GameObject regenerativeStrike = Instantiate(_chaSkillPrefab, caster.transform.position, caster.transform.rotation);
-        RegenerativeStrikeContoller skillCon = regenerativeStrike.GetComponent<RegenerativeStrikeContoller>();
+        GameObject vanguard = Instantiate(_chaSkillPrefab, caster.transform.position, caster.transform.rotation);
+        VanguardController skillCon = vanguard.GetComponent<VanguardController>();
 
-        return skillCon.Init(_chaSkillChance, _chaSkillValue, caster._characterState._chaAttack);
+        return skillCon.Init(_chaEffectValue);
     }
 
     // 사기 저하 패시브 스킬
     public float UseMoraleDecline(MyCharacterController caster, float value)
     {
         Debug.Log($"{caster._characterState._chaEnName} : 사기 저하 패시브 발동");
-        GameObject regenerativeStrike = Instantiate(_chaSkillPrefab, caster.transform.position, caster.transform.rotation);
-        RegenerativeStrikeContoller skillCon = regenerativeStrike.GetComponent<RegenerativeStrikeContoller>();
+        GameObject moraleDecline = Instantiate(_chaSkillPrefab, caster.transform.position, caster.transform.rotation);
+        MoraleDeclineController skillCon = moraleDecline.GetComponent<MoraleDeclineController>();
 
-        return skillCon.Init(_chaSkillChance, _chaSkillValue, caster._characterState._chaAttack);
+        return skillCon.Init(_chaSkillChance, _chaEffectValue);
     }
 
     // 강철의 파동 패시브 스킬
     public float UseWaveOfSteel(MyCharacterController caster, float value)
     {
         Debug.Log($"{caster._characterState._chaEnName} : 강철의 파동 패시브 발동");
-        GameObject regenerativeStrike = Instantiate(_chaSkillPrefab, caster.transform.position, caster.transform.rotation);
-        RegenerativeStrikeContoller skillCon = regenerativeStrike.GetComponent<RegenerativeStrikeContoller>();
+        GameObject waveOfSteel = Instantiate(_chaSkillPrefab, caster.transform.position, caster.transform.rotation);
+        WaveOfSteelController skillCon = waveOfSteel.GetComponent<WaveOfSteelController>();
 
         return skillCon.Init(_chaSkillChance, _chaSkillValue, caster._characterState._chaAttack);
     }
@@ -118,4 +190,5 @@ public class CharacterSkillDataSO : ScriptableObject
 
         return skillCon.Init(_chaSkillChance, _chaSkillValue, caster._characterState._chaAttack);
     }
+    #endregion
 }

--- a/Assets/05_KGW_Folder/Scripts/UI/CharacterSlotUI/CharacterInfoSlotUI.cs
+++ b/Assets/05_KGW_Folder/Scripts/UI/CharacterSlotUI/CharacterInfoSlotUI.cs
@@ -1,5 +1,4 @@
 using JJY;
-using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -46,7 +45,7 @@ public class CharacterInfoSlotUI : MonoBehaviour
     // 캐릭터 데이터 가져오기
     public void GetCharacterData(CharacterDataSO data)
     {
-        _characterPortrait.sprite = data.GachaBackground;
+        _characterPortrait.sprite = data._characterSprite;
         _characterHp.value = 1f;
         _characterMp.value = 0f;
     }

--- a/Assets/Resources/CSVData/Character/CharacterSkill.csv
+++ b/Assets/Resources/CSVData/Character/CharacterSkill.csv
@@ -1,13 +1,13 @@
-﻿캐릭터 스킬 ID	스킬 명	스킬 명(영문)	스킬 발동 타입	스킬 타겟 타입	스킬 효과 유형	스킬 발동 확률	스킬 지속 시간	스킬 효과 주기	스킬 타격 횟수	데미지 / 회복 계수	스킬 기타 계수	스킬 설명1
-chaSkillID	chaSkillName	chaSkillNameEn	chaSkillType	chaSkillTargetType	chaSkillEfftectType	chaSkillChance	chaSkillDuration	chaSkillTick	chaSkillHit	chaSkillValue	chaEffectValue	chaSkillDescription1
-int	string	string	string	string	string	float	float	float	int	float	float	string
-12001	재생의 일격	RegenerativeStrike	Passive	FriendlyAll	Heal	50	-1	-1	1	0.8	-1	공격 시 <chaSkillChance>%로  모든 아군의 체력을 <chaAttack>*<chaSkillValue> 회복 시킨다.
-12002	선봉장	Vanguard	Passive	FriendlyAll	BuffArm	100	-1	-1	1	1	30	모든 아군의 방어력을 <chaEffectValue> 만큼 상승시킨다.
-12003	사기 저하	MoraleDecline	Passive	EnemySingle	DebuffDmg	50	3	-1	1	1.2	20	공격 시 <chaSkillChance>%로 적의 공격력을 <chaEffectValue> 만큼 감소 시킨다.
-12004	강철의 파동	WaveOfSteel	Passive	EnemyAll	Direct	70	-1	-1	1	1.5	-1	공격 시 <chaSkillChance>%로 모든 적에게 <chaAttack>*<chaSkillValue>의 피해를 입힌다.
-12005	상처 조준	AimForTheWound	Passive	EnemySingle	Direct	50	-1	-1	1	2.2	-1	공격 시 <chaSkillChance>%로 적에게 <chaAttack>*<chaSkillValue>의 피해를 입힌다.
-12201	응원	Cheer	Active	FriendlyAll	BuffDmg	-1	5	-1	-1	-1	30	모든 아군의 공격력을 <chaEffectValue>% 만큼 상승시킨다.
-12202	보호 수류탄	ProtectiveGrenade	Active	FriendlyAll	Barrier	-1	-1	-1	1	2	-1	모든 적에게 수류탄을 던져 <chaAttack>*<chaSkillValue>의 피해를 입히고, 모든 아군에게 배리어 1회를 부여한다.
-12203	괴로운 향기	PainfulScent	Active	EnemyAll	DebuffArm	-1	5	-1	3	0.5	20	지독한 마늘향을 뿜어내어 <chaAttack>*<chaSkillValue> x <chaSkillHit>의 피해를 입히고, 모든 적의 방어력을  <chaEffectValue> 만큼 감소 시킨다.
-12204	늑대 베기	WolfSlash	Active	EnemyAll	Drain	-1	-1	-1	3	1.2	-1	검을 크게 휘둘러 모든 적에게 <chaAttack>*<chaSkillValue> x <chaSkillHit>의 피해를 입히고, 입힌 피해량 만큼 HP를 회복한다.
-12205	수호령의 분노	WrathOfTheGuardian	Active	EnemySingle	Direct	-1	-1	-1	5	1.2	-1	수호령을 불러내어 현재 공격 중인 대상에게 <chaAttack>*<chaSkillValue> x <chaSkillHit>의 강력한 피해를 입힌다.
+﻿"캐릭터 스킬 ID	스킬 명	스킬 명(영문)	스킬 발동 타입	스킬 타겟 타입	스킬 효과 유형	스킬 발동 확률	스킬 지속 시간	스킬 효과 주기	스킬 타격 횟수	데미지 / 회복 계수	스킬 기타 계수	스킬 설명1",
+"chaSkillID	chaSkillName	chaSkillNameEn	chaSkillType	chaSkillTargetType	chaSkillEfftectType	chaSkillChance	chaSkillDuration	chaSkillTick	chaSkillHit	chaSkillValue	chaEffectValue	chaSkillDescription1",
+"int	string	string	string	string	string	float	float	float	int	float	float	string",
+"12001	재생의 일격	RegenerativeStrike	Passive	FriendlyAll	Heal	50	-1	-1	1	0.8	-1	공격 시 <chaSkillChance>%로  모든 아군의 체력을 <chaAttack>*<chaSkillValue> 회복 시킨다.",
+"12002	선봉장	Vanguard	Passive	FriendlyAll	BuffArm	100	-1	-1	1	1	30	모든 아군의 방어력을 <chaEffectValue> 만큼 상승시킨다.",
+"12003	사기 저하	MoraleDecline	Passive	EnemySingle	DebuffDmg	50	3	-1	1	1.2	20	공격 시 <chaSkillChance>%로 적의 공격력을 <chaEffectValue> 만큼 감소 시킨다.",
+"12004	강철의 파동	WaveOfSteel	Passive	EnemyAll	Direct	70	-1	-1	1	1.5	-1	공격 시 <chaSkillChance>%로 모든 적에게 <chaAttack>*<chaSkillValue>의 피해를 입힌다.",
+"12005	상처 조준	AimForTheWound	Passive	EnemySingle	Direct	50	-1	-1	1	2.2	-1	공격 시 <chaSkillChance>%로 적에게 <chaAttack>*<chaSkillValue>의 피해를 입힌다.",
+"12201	응원	Cheer	Active	FriendlyAll	BuffDmg	-1	5	-1	-1	-1	30	모든 아군의 공격력을 <chaEffectValue>% 만큼 상승시킨다.",
+"12202	보호 수류탄	ProtectiveGrenade	Active	FriendlyAll	Barrier	-1	-1	-1	1	2	-1	모든 적에게 수류탄을 던져 <chaAttack>*<chaSkillValue>의 피해를 입히고", 모든 아군에게 배리어 1회를 부여한다.
+"12203	괴로운 향기	PainfulScent	Active	EnemyAll	DebuffArm	-1	5	0.2	3	0.5	20	지독한 마늘향을 뿜어내어 <chaAttack>*<chaSkillValue> x <chaSkillHit>의 피해를 입히고", 모든 적의 방어력을  <chaEffectValue> 만큼 감소 시킨다.
+"12204	늑대 베기	WolfSlash	Active	EnemyAll	Drain	-1	-1	0.2	3	1.2	-1	검을 크게 휘둘러 모든 적에게 <chaAttack>*<chaSkillValue> x <chaSkillHit>의 피해를 입히고", 입힌 피해량 만큼 HP를 회복한다.
+"12205	수호령의 분노	WrathOfTheGuardian	Active	EnemySingle	Direct	-1	-1	0.2	5	1.2	-1	수호령을 불러내어 현재 공격 중인 대상에게 <chaAttack>*<chaSkillValue> x <chaSkillHit>의 강력한 피해를 입힌다.",


### PR DESCRIPTION
요약
(이 PR은 무엇을 변경하거나 추가했는지 간단히 설명해주세요)
- 캐릭터의 액티브와 패시브 스킬 구현
작업 내용
(이 PR에서 어떤 작업이 있었는지 작성해주세요)
- 한서리 패시브, 액티브 스킬 구현 (재생의 일격, 응원)
- 백천아 패시브, 액티브 스킬 구현 (선봉장, 보호 수류탄)
- 소인랑 패시브, 액티브 스킬 구현 (사기 저하, 괴로운 향기)
- 고서은 패시브, 액티브 스킬 구현 (강철의 파동, 늑대 베기)
- 백웅 패시브, 액티브 스킬 구현 (상처 조준, 수호령의 분노)
- 엄모안 패시브 스킬 적용
- 육호연 패시브 스킬 적용
- 산드레 패시브 스킬 적용
- 달리아 패시브 스킬 적용
- 장희빈 패시브 스킬 적용

체크리스트
 코드가 정상적으로 빌드/실행된다
 기능이 정상 동작한다
 심각한 버그나 예상치 못한 문제는 없다