### PR TITLE
[Fix] 상점 할인 유물 보유 시 상점 할인이 제대로 안되는 버그 수정

### DIFF
--- a/Assets/06_SDW_Folder/Scenes/SDW_RoguelikeScene.unity
+++ b/Assets/06_SDW_Folder/Scenes/SDW_RoguelikeScene.unity
@@ -12796,6 +12796,7 @@ MonoBehaviour:
   refreshCost: 5
   ingredientDatabase: {fileID: 11400000, guid: ddb682d1b45fc6648b273d2d988f0189, type: 2}
   selectedSlotIndex: -1
+  hasDiscountRelic: 0
   _shoppingUI: {fileID: 1524937423}
 --- !u!1 &672205251
 GameObject:
@@ -31393,6 +31394,7 @@ MonoBehaviour:
   - {fileID: 1310320960}
   - {fileID: 1259133390}
   - {fileID: 1272144704}
+  _storeButton: {fileID: 1518380863}
   _resetButton: {fileID: 1607464652}
   _buyButton: {fileID: 204480630}
   _mainPanelRect: {fileID: 507581696}

--- a/Assets/06_SDW_Folder/Scripts/UI/RogueLikeScene/ShoppingUI.cs
+++ b/Assets/06_SDW_Folder/Scripts/UI/RogueLikeScene/ShoppingUI.cs
@@ -17,6 +17,7 @@ namespace SDW
         [SerializeField] private List<TextMeshProUGUI> _ingredientPriceText;
 
         [Header("Button Components")]
+        [SerializeField] private Button _storeButton;
         [SerializeField] private Button _resetButton;
         [SerializeField] private Button _buyButton;
         [SerializeField] private RectTransform _mainPanelRect;
@@ -43,6 +44,7 @@ namespace SDW
 
         private void OnEnable()
         {
+            _storeButton.onClick.AddListener(StoreButtonClicked);
             _resetButton.onClick.AddListener(ResetButtonClicked);
             _buyButton.onClick.AddListener(BuyButtonClicked);
 
@@ -135,7 +137,11 @@ namespace SDW
         }
 
         #region Button Methods
-
+        private void StoreButtonClicked()
+        {
+            _ingredientStoreManager.SyncSlotPrices();
+            ResetIngredientColor();
+        }
         private void ResetButtonClicked()
         {
             _ingredientStoreManager.RefreshStore();

--- a/Assets/08_JJY_Folder/Scripts/Manager/IngredientStoreUIManager.cs
+++ b/Assets/08_JJY_Folder/Scripts/Manager/IngredientStoreUIManager.cs
@@ -39,13 +39,11 @@ namespace JJY
             public bool sold;
         }
 
-        private List<SlotData> slotDatas = new List<SlotData>();
+        private List<SlotData> slotDatas = new List<SlotData>(); // 실제 상점의 슬릇 데이터
 
         public int selectedSlotIndex = -1;
         private Ingredient[] allIngredients;
         private bool logAction = true;
-        // On/Off하며 테스트
-        [SerializeField] private bool hasDiscountRelic;
         [SerializeField] private ShoppingUI _shoppingUI;
 
         private void Awake()
@@ -58,7 +56,6 @@ namespace JJY
                 return;
             }
         }
-
         private void Start()
         {
             StartCoroutine(DelayedInit());
@@ -110,11 +107,25 @@ namespace JJY
         //             _coin.AddYeopjeon(500);
         //         }
         // #endif
-
-        private void HasDiscountRelic()
+        private float GetShopDiscountMultiplier()
         {
-            hasDiscountRelic = false;
-            hasDiscountRelic = GameManager.Instance.InGameItem.HasRelic(RelicTarget.Shop);
+            return GameManager.Instance.InGameItem.HasRelic(RelicTarget.Shop) ? 0.7f : 1f;
+        }
+        public void SyncSlotPrices()
+        {
+            if (slotDatas == null || slotDatas.Count == 0) return;
+            if (ingredientMap == null) InitIngredients();
+
+            float multiplier = GetShopDiscountMultiplier();
+
+            for (int i = 0; i < slotDatas.Count; i++)
+            {
+                IngredientData data = null;
+                if (ingredientMap != null) ingredientMap.TryGetValue(slotDatas[i].ingredient, out data);
+
+                slotDatas[i].price = Mathf.Max(0, Mathf.RoundToInt(data.cost * multiplier));
+            }
+            UpdateSlotUI();
         }
         private void InitStoreSlots()
         {
@@ -124,7 +135,6 @@ namespace JJY
                 slotDatas.Add(new SlotData { ingredient = Ingredient.None, price = 0, sold = false });
             }
 
-            HasDiscountRelic();
             for (int i = 0; i < slotDatas.Count; i++)
             {
                 // 랜덤 선택(중복 허용)
@@ -134,12 +144,11 @@ namespace JJY
                 if (ingredientMap != null) ingredientMap.TryGetValue(chosen, out data);
 
                 slotDatas[i].ingredient = data.ingredient;
-                // 할인율 변경 시 이곳에서도 변경해야함.
-                if (hasDiscountRelic) slotDatas[i].price = Mathf.RoundToInt(data.cost * 0.7f);
-                else slotDatas[i].price = data.cost;
-                slotDatas[i].price = data.cost;
+                // slotDatas[i].price = data.cost;
                 slotDatas[i].sold = false;
             }
+
+            SyncSlotPrices();
 
             selectedSlotIndex = -1;
             UpdateSlotUI();
@@ -159,7 +168,6 @@ namespace JJY
             }
             _coin.SubtractYeopjeon(5);
 
-            HasDiscountRelic();
             for (int i = 0; i < slotDatas.Count; i++)
             {
                 // 랜덤 선택(중복 허용)
@@ -169,12 +177,11 @@ namespace JJY
                 if (ingredientMap != null) ingredientMap.TryGetValue(chosen, out data);
 
                 slotDatas[i].ingredient = data.ingredient;
-                // 할인율 변경 시 이곳에서도 변경해야함.
-                if (hasDiscountRelic) slotDatas[i].price = Mathf.RoundToInt(data.cost * 0.7f);
-                else slotDatas[i].price = data.cost;
-                slotDatas[i].price = data.cost;
+                // slotDatas[i].price = data.cost;
                 slotDatas[i].sold = false;
             }
+
+            SyncSlotPrices();
 
             UpdateSlotUI();
             if (logAction) Debug.Log($"상점 새로고침:엽전 {_coin.yeopjeon}개 보유중");


### PR DESCRIPTION
- 버그 원인 : Awake에서 상점 슬릇 초기화 작업 -> 유물 획득 -> 상점 확인 시 할인이 적용 안 됨.
- 해결 : 상점 버튼 클릭 시 가격을 재설정하고 동기화하는 코드 실행.