### PR TITLE
[Fix] Battle GiveUp Character HP Renewal Bug

### DIFF
--- a/Assets/05_KGW_Folder/Scripts/Manager/Battle/BattleManager.cs
+++ b/Assets/05_KGW_Folder/Scripts/Manager/Battle/BattleManager.cs
@@ -43,6 +43,9 @@ public class BattleManager : MonoBehaviour
     public List<MonsterController> _monsters = new List<MonsterController>();
     public List<MonsterController> _bossMonster = new List<MonsterController>();
 
+    // 생성된 캐릭터 스텟 관리용 보관
+    public List<MyCharacterController> _characterStats = new List<MyCharacterController>();
+
     public BattleUI _battleUI;
     private Coroutine _armorRoutine;
     public BattleEventType _battleType;
@@ -189,6 +192,7 @@ public class BattleManager : MonoBehaviour
             // 생성된 캐릭터 저장
             var createCharacter = character.GetComponent<MyCharacterController>();
             _characters.Add(createCharacter);
+            _characterStats.Add(createCharacter);
 
             // 캐릭터 데이터 전달
             _battleUI._infoSlot[i].GetCharacterData(characterData);
@@ -492,6 +496,18 @@ public class BattleManager : MonoBehaviour
             default:
                 break;
         }
+    }
+
+    // 중도 포기 시 캐릭터 체력 갱신
+    public void GiveUpCharacterRenewal()
+    {
+        foreach (var cha in _characterStats)
+        {
+            GameManager.Instance.CharacterBattleDataSave._chaHpSave[cha._characterState._chaEnName] = cha._characterState._chaMaxHP;
+            Debug.Log($"{cha._characterState._chaEnName}의 체력이 {cha._characterState._chaMaxHP}로 저장이 되었습니다.");
+        }
+
+        _characterStats.Clear();
     }
 
     private void BattleEnd()

--- a/Assets/06_SDW_Folder/Scripts/UI/RogueLikeScene/PopupSettingUI.cs
+++ b/Assets/06_SDW_Folder/Scripts/UI/RogueLikeScene/PopupSettingUI.cs
@@ -69,15 +69,8 @@ namespace SDW
 
         private void GiveUpButtonClicked()
         {
-            Debug.Log($"정산된 스코어 : {GameManager.Instance.Score}");
             // 캐릭터의 체력 갱신
-
-            //foreach (var cha in _battleManager._characters)
-            //{
-            //    GameManager.Instance.CharacterBattleDataSave._chaHpSave[cha._characterState._chaEnName] = cha._characterState._chaMaxHP;
-            //    Debug.Log($"{cha._characterState._chaEnName}의 체력이 {cha._characterState._chaMaxHP}로 저장이 되었습니다.");
-            //}
-            //_battleManager._characters.Clear();
+            _battleManager.GiveUpCharacterRenewal();
 
             _masterVolumeSlider.Cancel();
             _backgroundVolumeSlider.Cancel();


### PR DESCRIPTION
- 배틀 진행 중 중도포기 시 캐릭터의 체력이 갱신이 안되는 버그 확인
- 전투에 참가한 캐릭터가 전투 후 초기화 됨으로 체력을 갱신할 수 없어 캐릭터의 스텟을 관리하는 리스트 추가하여 캐릭터 생성시 리스트에 캐릭터를 저장하고 중도 포기 시 체력 갱신 후 리스트 초기화 진행

< 체크리스트 >
[o] 코드가 정상적으로 빌드/실행된다
[o] 기능이 정상 동작한다
[o] 심각한 버그나 예상치 못한 문제는 없다