### PR TITLE
[Fix] Lobby Movement Character Hp Renewal Bug

### DIFF
--- a/Assets/05_KGW_Folder/Scripts/Manager/Battle/BattleManager.cs
+++ b/Assets/05_KGW_Folder/Scripts/Manager/Battle/BattleManager.cs
@@ -503,7 +503,7 @@ public class BattleManager : MonoBehaviour
     }
 
     // 중도 포기 시 캐릭터 체력 갱신
-    public void GiveUpCharacterRenewal()
+    public void ClearCharacterHp()
     {
         foreach (var cha in _characterStats)
         {

--- a/Assets/06_SDW_Folder/Scripts/UI/RogueLikeScene/PopupSettingUI.cs
+++ b/Assets/06_SDW_Folder/Scripts/UI/RogueLikeScene/PopupSettingUI.cs
@@ -17,7 +17,6 @@ namespace SDW
         [SerializeField] private Button _saveButton;
         [SerializeField] private GameObject _backgroundObject;
         private TweenAnimation _tweenAnimation;
-        private BattleManager _battleManager;
 
         public Action<UIName> OnUIOpenRequested;
         public Action<UIName> OnUICloseRequested;
@@ -27,12 +26,6 @@ namespace SDW
         {
             _panelContainer.SetActive(false);
             _tweenAnimation = GetComponent<TweenAnimation>();
-        }
-
-        protected override void Start()
-        {
-            base.Start();
-            _battleManager = FindObjectOfType<BattleManager>();
         }
 
         private void OnEnable()
@@ -69,9 +62,6 @@ namespace SDW
 
         private void GiveUpButtonClicked()
         {
-            // 캐릭터의 체력 갱신
-            _battleManager.GiveUpCharacterRenewal();
-
             _masterVolumeSlider.Cancel();
             _backgroundVolumeSlider.Cancel();
             _effectVolumeSlider.Cancel();

--- a/Assets/06_SDW_Folder/Scripts/UI/RogueLikeScene/RoguelikeClosingUI.cs
+++ b/Assets/06_SDW_Folder/Scripts/UI/RogueLikeScene/RoguelikeClosingUI.cs
@@ -49,6 +49,7 @@ namespace SDW
         private float _cutLineAlpha;
         private int _totalResultScore;
         private GameManager _gameManager;
+        private BattleManager _battleManager;
 
         public Action<UIName> OnUICloseRequested;
 
@@ -62,6 +63,12 @@ namespace SDW
             _cutLineAlpha = _cutLineImage.color.a;
             ClearAlpha();
             InactiveUI();
+        }
+
+        protected override void Start()
+        {
+            base.Start();
+            _battleManager = FindObjectOfType<BattleManager>();
         }
 
         private void OnEnable()
@@ -261,6 +268,7 @@ namespace SDW
             _gameManager.InGameItem.ClearItemCounts();
             _gameManager.ClearScore();
             _gameManager.ClearStageCount();
+            _battleManager.ClearCharacterHp();
 
             //todo 테스트 이후 주석 제거
             // _gameManager.Coin.ClearYeopjeon();


### PR DESCRIPTION
- 전투 중 로비 이동 시 캐릭터의 체력이 갱신이 되지 않은 버그 확인
- 중도 포기 버튼 클릭에만 캐릭터의 체력 갱신으로 인한 원인 파악
- 결산창 UI의 확인 버튼에 캐릭터의 체력 갱신 구현 

< 체크리스트 >
[o] 코드가 정상적으로 빌드/실행된다
[o] 기능이 정상 동작한다
[o] 심각한 버그나 예상치 못한 문제는 없다