### PR TITLE
[Fix] Elite Battle Clear, Level Text

### DIFF
--- a/Assets/05_KGW_Folder/Scripts/UI/ClearChapterUI/ClearStageUI.cs
+++ b/Assets/05_KGW_Folder/Scripts/UI/ClearChapterUI/ClearStageUI.cs
@@ -14,6 +14,7 @@ namespace SDW
         [Header("UI Components")]
         [SerializeField] private Button _confirmButton; // 랜덤 인카운터로 이동 버튼
         [SerializeField] private TextMeshProUGUI _yeopjeonText;
+        [SerializeField] private TextMeshProUGUI _selectText;
         [SerializeField] private Transform content;
         [SerializeField] private RelicUI relicPrefab;
         [SerializeField] public GameObject RelicWindow;
@@ -59,7 +60,9 @@ namespace SDW
             {
                 int getYeopjeon = MapView.Instance._eventManager.CombatRewardAmount;
 
-                RelicWindow.SetActive(false);
+                _selectText.text = "전투에서 승리했습니다!";
+                _confirmButton.interactable = true;
+                content.gameObject.SetActive(false);
                 GameManager.Instance.Coin.AddYeopjeon(getYeopjeon);
                 UpdateYeopjeonText(GameManager.Instance.Coin.bonus);
             }

--- a/Assets/06_SDW_Folder/Scenes/SDW_RoguelikeScene.unity
+++ b/Assets/06_SDW_Folder/Scenes/SDW_RoguelikeScene.unity
@@ -2230,7 +2230,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 29.915, y: -75}
+  m_AnchoredPosition: {x: 14.900002, y: -75}
   m_SizeDelta: {x: -4.17, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &142714310
@@ -5037,8 +5037,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 53.5925, y: -75}
-  m_SizeDelta: {x: -116.815, y: 50}
+  m_AnchoredPosition: {x: 44.76, y: -75}
+  m_SizeDelta: {x: -99.14, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &246496535
 MonoBehaviour:
@@ -14789,7 +14789,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 25.564999, y: -75}
+  m_AnchoredPosition: {x: 14.900002, y: -75}
   m_SizeDelta: {x: -12.870001, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &718932181
@@ -17153,6 +17153,7 @@ MonoBehaviour:
   _panelContainer: {fileID: 371453495}
   _confirmButton: {fileID: 1171042209}
   _yeopjeonText: {fileID: 1217747321}
+  _selectText: {fileID: 2094354255}
   content: {fileID: 1410356852}
   relicPrefab: {fileID: 9136602848948372974, guid: 98c5d8002c0f47340bdd879e3049d661, type: 3}
   RelicWindow: {fileID: 371453495}
@@ -26820,8 +26821,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 53.487503, y: -75}
-  m_SizeDelta: {x: -117.024994, y: 50}
+  m_AnchoredPosition: {x: 44.19, y: -75}
+  m_SizeDelta: {x: -98.42, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1254565343
 MonoBehaviour:
@@ -31215,8 +31216,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 56.001, y: -75}
-  m_SizeDelta: {x: -111.998, y: 50}
+  m_AnchoredPosition: {x: 46.7, y: -75}
+  m_SizeDelta: {x: -93.39, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1431835982
 MonoBehaviour:
@@ -42559,7 +42560,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 27.739998, y: -75}
+  m_AnchoredPosition: {x: 14.900002, y: -75}
   m_SizeDelta: {x: -8.52, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2062908856

--- a/Assets/08_JJY_Folder/Scripts/Manager/CharacterLevelUpUIManager.cs
+++ b/Assets/08_JJY_Folder/Scripts/Manager/CharacterLevelUpUIManager.cs
@@ -538,6 +538,7 @@ namespace JJY
                 }
 
                 var newLevelData = GameManager.Instance.CharacterData.ChaLevelUpStatData[curLevel];
+                GameManager.Instance.CharacterBattleDataSave._chaLevel[chaKey.ChaEnName] = GameManager.Instance.CharacterData.CharEnNameLevel[chaKey.ChaEnName];
 
                 expBar.fillAmount = (float)curExp / newLevelData.ChaLevelPoint;
 


### PR DESCRIPTION
- 사건 전투로 엽전을 획득하는 전투에서 클리어 시 클리어 팝업에 유물 선택을 제외한 엽전 획득 정보만 나오도록 수정
- 편성창에서 캐릭터의 레벨 텍스트 수정

< 체크리스트 >
[o] 코드가 정상적으로 빌드/실행된다
[o] 기능이 정상 동작한다
[o] 심각한 버그나 예상치 못한 문제는 없다