### PR TITLE
[Fix] Character Hp, IronBull Rush Bug Fix

### DIFF
--- a/Assets/05_KGW_Folder/Animations/Monsters/IronBull/Skill2.anim
+++ b/Assets/05_KGW_Folder/Animations/Monsters/IronBull/Skill2.anim
@@ -14,7 +14,50 @@ AnimationClip:
   m_RotationCurves: []
   m_CompressedRotationCurves: []
   m_EulerCurves: []
-  m_PositionCurves: []
+  m_PositionCurves:
+  - curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: {x: 0.079, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 2
+        value: {x: 0.079, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 2.5
+        value: {x: -1.1, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      - serializedVersion: 3
+        time: 3.0166667
+        value: {x: 0.079, y: 0, z: 0}
+        inSlope: {x: 0, y: 0, z: 0}
+        outSlope: {x: 0, y: 0, z: 0}
+        tangentMode: 0
+        weightedMode: 0
+        inWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+        outWeight: {x: 0.33333334, y: 0.33333334, z: 0.33333334}
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    path: 
   m_ScaleCurves: []
   m_FloatCurves: []
   m_PPtrCurves:
@@ -70,6 +113,15 @@ AnimationClip:
     genericBindings:
     - serializedVersion: 2
       path: 0
+      attribute: 1
+      script: {fileID: 0}
+      typeID: 4
+      customType: 0
+      isPPtrCurve: 0
+      isIntCurve: 0
+      isSerializeReferenceCurve: 0
+    - serializedVersion: 2
+      path: 0
       attribute: 0
       script: {fileID: 0}
       typeID: 212
@@ -116,8 +168,152 @@ AnimationClip:
     m_KeepOriginalPositionXZ: 0
     m_HeightFromFeet: 0
     m_Mirror: 0
-  m_EditorCurves: []
+  m_EditorCurves:
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0.079
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2
+        value: 0.079
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2.5
+        value: -1.1
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 3.0166667
+        value: 0.079
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.x
+    path: 
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2.5
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 3.0166667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.y
+    path: 
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
+  - serializedVersion: 2
+    curve:
+      serializedVersion: 2
+      m_Curve:
+      - serializedVersion: 3
+        time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 2.5
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 3.0166667
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      m_PreInfinity: 2
+      m_PostInfinity: 2
+      m_RotationOrder: 4
+    attribute: m_LocalPosition.z
+    path: 
+    classID: 4
+    script: {fileID: 0}
+    flags: 0
   m_EulerEditorCurves: []
-  m_HasGenericRootTransform: 0
+  m_HasGenericRootTransform: 1
   m_HasMotionFloatCurves: 0
   m_Events: []

--- a/Assets/05_KGW_Folder/Prefabs/03_Skills/MonsterSkills/SkillsData/SavageRush/SavageRushController.cs
+++ b/Assets/05_KGW_Folder/Prefabs/03_Skills/MonsterSkills/SkillsData/SavageRush/SavageRushController.cs
@@ -7,15 +7,12 @@ public class SavageRushController : MonoBehaviour
     private float _skillDamage;
     private MyCharacterController _character;
     private MonsterController _monster;
-    private Vector3 _position;
-    private Coroutine _rushRoutine;
 
     public void Init(MonsterController caster, MyCharacterController target, float damageValue)
     {
         _skillDamage = caster._monsterState._monAttack * damageValue;
         _character = target;
         _monster = caster;
-        _position = caster.transform.position;
 
         CharacterSavageRush();
     }
@@ -25,78 +22,19 @@ public class SavageRushController : MonoBehaviour
     {
         if (!_character._isAlive) return;
 
-        if (_character._battleManager._isGameOver)
-        {
-            RushCoroutineStop();
-        }
-
-        //_rushRoutine = StartCoroutine(RushCoroutine());
-
-        // 2초의 대기 시간 후 돌진 사용
-        Invoke(nameof(StartRush), 2f);
+        // 2초의 대기 시간 후 돌진 상호작용
+        Invoke(nameof(RushPlay), 2f);
     }
 
-    // 돌진 시작
-    private void StartRush()
+    // 돌진 플레이
+    private void RushPlay()
     {
-        _rushRoutine = StartCoroutine(RushCoroutine());
-    }
-
-    private IEnumerator RushCoroutine()
-    {
-        Vector3 startPos = _position;
-        Vector3 endPos;
-        Vector3 rushDir = Vector3.right;
-        float rushTime = 0.5f;
-        float timer = 0f;
-        float returnDuration = 0.5f;
-
-        // 그로기 상태에서는 돌진 금지
-        if (_monster._isStern)
-        {
-            yield break;
-        }
+        // 공격 대상의 캐릭터 공격
+        _character.TakeDamage(_skillDamage, _monster._monsterState._monAccuracy);
 
         // 난폭한 돌진 사운드 플레이
         GameManager.Instance.Audio.Play2DSFX(AudioClipName.IronBullSkill_2);
 
-        // 앞으로 돌진
-        while (timer < rushTime)
-        {
-            _monster.transform.position += rushDir * _monster._monsterState._monMoveSpeed * 10f * Time.deltaTime;
-            timer += Time.deltaTime;
-
-            yield return null;
-        }
-
-        endPos = _monster.transform.position;
-        timer = 0f;
-
-        // 공격 대상의 캐릭터 공격
-        _character.TakeDamage(_skillDamage, _monster._monsterState._monAccuracy);
-
-        // 돌진 전 위치로 돌아오기
-        while (timer < returnDuration)
-        {
-            _monster.transform.position = Vector3.Lerp(endPos, startPos, timer /  returnDuration);
-            timer += Time.deltaTime;
-
-            yield return null;
-        }
-
-        // 복귀 위치 고정
-        _monster.transform.position = startPos;
-
         Destroy(gameObject);
-    }
-
-    // 코루틴 정지
-    private void RushCoroutineStop()
-    {
-        if(_rushRoutine != null)
-        {
-            StopCoroutine(_rushRoutine);
-            _rushRoutine = null;
-        }
     }
 }

--- a/Assets/05_KGW_Folder/Scripts/Characters/MyCharacterController.cs
+++ b/Assets/05_KGW_Folder/Scripts/Characters/MyCharacterController.cs
@@ -300,6 +300,8 @@ public class MyCharacterController : UnitBaseData
         // 체력이 0이 됨
         if (_characterState._chaCurrentHP <= 0)
         {
+            _characterState._chaCurrentHP = 0f;
+            OnHpChange?.Invoke(0f);
             // 유닛의 죽음
             Death();
         }

--- a/Assets/05_KGW_Folder/Scripts/Monsters/MonsterController.cs
+++ b/Assets/05_KGW_Folder/Scripts/Monsters/MonsterController.cs
@@ -367,6 +367,8 @@ public class MonsterController : UnitBaseData
         // 체력이 0이 됨
         if (_monsterState._monCurrentHP <= 0)
         {
+            _monsterState._monCurrentHP = 0f;
+            _monsterHp.value = 0f;
             _monAnimatior.Play(Death_Hash);
             // 유닛의 죽음
             Death();
@@ -531,6 +533,8 @@ public class MonsterController : UnitBaseData
         if (_breakCount >= _monsterState._monbreakGage)
         {
             _isStern = true;
+            _skill1Timer = 0f;
+            _skill2Timer = 0f;
 
             _breakCount = 0;
             // 그로기 수치 UI

--- a/Assets/05_KGW_Folder/Scripts/UI/CharacterSlotUI/CharacterInfoSlotUI.cs
+++ b/Assets/05_KGW_Folder/Scripts/UI/CharacterSlotUI/CharacterInfoSlotUI.cs
@@ -86,10 +86,7 @@ public class CharacterInfoSlotUI : MonoBehaviour
     // 받은 데미지로 체력바 변화
     private void HpChangeCheck(float _curHp)
     {
-        if (_characterHp)
-        {
-            _characterHp.value = _curHp;
-        }
+        _characterHp.value = _curHp;
     }
 
     // 충전되는 마나바 변화


### PR DESCRIPTION
- 캐릭터가 사망을 했지만 캐릭터의 체력UI에 체력이 남아 있는 버그 확인
   - 캐릭터의 사망 메서드가 체력UI의 변화 메서드보다 먼저 호출이 되어 발생하는 원인 확인
   - 캐릭터의 사망 시 체력과 UI 변화 코드 추가
  
- 황소 보스의 돌진 스킬 중 그로기 발생 시 현재 위치에서 멈추는 버그 확인하여 수정
   - 황소 보스의 돌진이 실제로 보스가 이동해서 돌진 중 그로기 시 돌진 위치에서 멈추는 원인 확인
   - 보스가 실제로 이동하면 캐릭터들도 살짝 움찔하고 보스의 경우 실제로 움직이지 않도록 애니메이션으로 돌진 모션 수정

< 체크리스트 >
[o] 코드가 정상적으로 빌드/실행된다
[o] 기능이 정상 동작한다
[o] 심각한 버그나 예상치 못한 문제는 없다