### PR TITLE
[Fix] Character Spawn Layer Bug

### DIFF
--- a/Assets/05_KGW_Folder/Scripts/Manager/Battle/BattleManager.cs
+++ b/Assets/05_KGW_Folder/Scripts/Manager/Battle/BattleManager.cs
@@ -120,13 +120,6 @@ public class BattleManager : MonoBehaviour
             _isSpawned || !_isBattleStarted) return;
         //if(_isDownloaded) return;
 
-        //_isLocalBoss = ;
-        //todo BossFinal과 Boss는 구분되어야 함 - 아래 코드는 Test 코드
-        //_isLastBoss = RoguelikeManager.Instance.MonsterType == BattleEventType.Boss;
-        // _monsterList = monsterData[stageName].NormalMonsters;
-        // _eliteList = monsterData[stageName].EliteMonsters;
-        // _bossList = monsterData[stageName].BossMonsters;
-
         _battleType = RoguelikeManager.Instance.MonsterType;
         _stageNum = GameManager.Instance.Stage;
         _chapterNum = GameManager.Instance.Chapter;
@@ -189,7 +182,21 @@ public class BattleManager : MonoBehaviour
             var characterOIL = character.GetComponentInChildren<SpriteRenderer>();
 
             // 마직막 캐릭터를 맨 앞으로 보여주기
-            characterOIL.sortingOrder = 10 + count - i;
+            switch (spawnPoint.name)
+            {
+                case "SpawnPoint_1":
+                case "ResurrectionPoint_1":
+                    characterOIL.sortingOrder = 13;
+                    break;
+                case "SpawnPoint_2":
+                case "ResurrectionPoint_2":
+                    characterOIL.sortingOrder = 12;
+                    break;
+                case "SpawnPoint_3":
+                case "ResurrectionPoint_3":
+                    characterOIL.sortingOrder = 11;
+                    break;
+            }
 
             // 생성된 캐릭터 저장
             var createCharacter = character.GetComponent<MyCharacterController>();


### PR DESCRIPTION
- 캐릭터 스폰 시 생성된 캐릭터의 레이어가 스폰위치에 맞지 않아 시각적인 부분에서 자연스럽지 않게 겹쳐지는 현상 확인
   - 캐릭터 스폰 시 가장 아래의 스폰지역에서 생성된 캐릭터의 레이어를 가장 위로 오도록 지정
   - 스폰위치 1,2,3 순서대로 위 -> 아래로 지정하여 수정
   - 테스트 진행 시 스폰위치1에서 생성된 캐릭터는 항상위에서 보여짐을 확인

< 체크리스트 >
[o] 코드가 정상적으로 빌드/실행된다
[o] 기능이 정상 동작한다
[o] 심각한 버그나 예상치 못한 문제는 없다