### PR TITLE
[Fix] 보스 몬스터 체력바 관련 수정, 정산 시 엽전 초기화

### DIFF
--- a/Assets/05_KGW_Folder/Scripts/Manager/Battle/BattleUI.cs
+++ b/Assets/05_KGW_Folder/Scripts/Manager/Battle/BattleUI.cs
@@ -49,7 +49,7 @@ public class BattleUI : BaseUI
         _isFast = false;
         _panelContainer.SetActive(false);
         _bottomUI.SetActive(false);
-        if (!GameManager.Instance._canFaster) _fastButtonX2.interactable = false;
+        if (!GameManager.Instance.CanFaster) _fastButtonX2.interactable = false;
         else _fastButtonX2.interactable = true;
 
         _fastButtonX2.onClick.AddListener(X2FastButtonClick);

--- a/Assets/05_KGW_Folder/Scripts/Monsters/MonsterController.cs
+++ b/Assets/05_KGW_Folder/Scripts/Monsters/MonsterController.cs
@@ -315,7 +315,7 @@ public class MonsterController : UnitBaseData
     // 리셋 애니메이션
     private void ResetAnimation()
     {
-        if (_isUseSkill2) 
+        if (_isUseSkill2)
         {
             // 타이머 초기화
             _skill2Timer = 0f;
@@ -368,7 +368,9 @@ public class MonsterController : UnitBaseData
         if (_monsterState._monCurrentHP <= 0)
         {
             _monsterState._monCurrentHP = 0f;
-            _monsterHp.value = 0f;
+
+            if (gameObject.layer != LayerMask.NameToLayer("Boss"))
+                _monsterHp.value = 0f;
             _monAnimatior.Play(Death_Hash);
             // 유닛의 죽음
             Death();
@@ -558,7 +560,6 @@ public class MonsterController : UnitBaseData
         // 그로기 초기화
         _monAnimatior.Play(Idle_Hash);
         _isStern = false;
-
     }
 
     private void ApplyGroggy(float value)

--- a/Assets/06_SDW_Folder/Scripts/Manager/FirebaseManager.cs
+++ b/Assets/06_SDW_Folder/Scripts/Manager/FirebaseManager.cs
@@ -335,12 +335,15 @@ namespace SDW
                 { "buyAdRemover", false },
                 { "gachaCount", 0 },
                 { "chapter", 1 },
+                { "stage", 1 },
                 { "stamina", 120 },
                 { "lastStaminaUpdate", DateTime.UtcNow.AddHours(9).ToString("yyyy-MM-dd HH:mm:ss") },
                 { "battleCount", 0 },
                 { "relicCount", 0 },
                 { "cookCount", 0 },
-                { "stageCount", 0 }
+                { "stageCount", 0 },
+                { "canGacha", false },
+                { "canFaster", false }
             };
 
             foreach (string grade in Enum.GetNames(typeof(RelicGrade)))
@@ -577,12 +580,15 @@ namespace SDW
                 { "buyAdRemover", false },
                 { "gachaCount", 0 },
                 { "chapter", 1 },
+                { "stage", 1 },
                 { "stamina", 120 },
                 { "lastStaminaUpdate", DateTime.UtcNow.AddHours(9).ToString("yyyy-MM-dd HH:mm:ss") },
                 { "battleCount", 0 },
                 { "relicCount", 0 },
                 { "cookCount", 0 },
-                { "stageCount", 0 }
+                { "stageCount", 0 },
+                { "canGacha", false },
+                { "canFaster", false }
             };
             _etcData = etcData;
 
@@ -1209,6 +1215,60 @@ namespace SDW
                 if (task.IsFaulted)
                 {
                     Debug.LogWarning($"Chapter 저장 실패: {task.Exception.Message}");
+                }
+            });
+        }
+
+        public void SetCanFaster(bool canFaster)
+        {
+            var updateData = new Dictionary<string, object>
+            {
+                { "etcData/canFaster", canFaster }
+            };
+
+            _etcData["canFaster"] = canFaster;
+
+            _db.Child("users").Child(_auth.CurrentUser.UserId).UpdateChildrenAsync(updateData).ContinueWithOnMainThread(task =>
+            {
+                if (task.IsFaulted)
+                {
+                    Debug.LogWarning($"CanFaster 저장 실패: {task.Exception.Message}");
+                }
+            });
+        }
+
+        public void SetCanGacha(bool canGacha)
+        {
+            var updateData = new Dictionary<string, object>
+            {
+                { "etcData/canGacha", canGacha }
+            };
+
+            _etcData["canGacha"] = canGacha;
+
+            _db.Child("users").Child(_auth.CurrentUser.UserId).UpdateChildrenAsync(updateData).ContinueWithOnMainThread(task =>
+            {
+                if (task.IsFaulted)
+                {
+                    Debug.LogWarning($"CanGacha 저장 실패: {task.Exception.Message}");
+                }
+            });
+        }
+
+        public void SetStage(int stage)
+        {
+            var updateData = new Dictionary<string, object>
+            {
+                { "etcData/stage", stage }
+            };
+
+            _etcData["stage"] = stage;
+
+            _db.Child("users").Child(_auth.CurrentUser.UserId).UpdateChildrenAsync(updateData).ContinueWithOnMainThread(task =>
+            {
+                if (task.IsFaulted)
+                {
+                    Debug.LogWarning($"Stage 저장 실패: {task.Exception.Message}");
                 }
             });
         }

--- a/Assets/06_SDW_Folder/Scripts/Manager/GameManager.cs
+++ b/Assets/06_SDW_Folder/Scripts/Manager/GameManager.cs
@@ -136,7 +136,17 @@ namespace SDW
         private bool _isLoaded;
         public bool _isStageClear;
 
-        public bool _canFaster = false; //배속 기능
+        private bool _canFaster = false;
+
+        public bool CanFaster
+        {
+            get => _canFaster;
+            set
+            {
+                _canFaster = value;
+                _firebase.SetCanFaster(_canFaster);
+            }
+        }
 
         private bool _canGacha;
 
@@ -146,6 +156,7 @@ namespace SDW
             set
             {
                 _canGacha = value;
+                _firebase.SetCanGacha(_canGacha);
                 OnCanGachaChanged?.Invoke(_canGacha);
             }
         } //가챠 기능
@@ -324,7 +335,11 @@ namespace SDW
         /// <summary>
         /// 다음 스테이지로 이동하기 위해 스테이지 증가
         /// </summary>
-        public void NextStage() => _stage++;
+        public void NextStage()
+        {
+            _stage++;
+            _firebase.SetStage(_stage);
+        }
 
         /// <summary>
         /// 다운로드 완료 상태를 설정
@@ -353,9 +368,30 @@ namespace SDW
             _buyAdRemover = Convert.ToBoolean(etcData["buyAdRemover"]);
             _gachaCount = Convert.ToInt32(etcData["gachaCount"]);
             _chapter = Convert.ToInt32(etcData["chapter"]);
+
+            if (!etcData.ContainsKey("stage"))
+            {
+                _firebase.SetStage(1);
+                _stage = 1;
+            }
+            else _stage = Convert.ToInt32(etcData["stage"]);
             _stamina = Convert.ToInt32(etcData["stamina"]);
             //todo stamina 시간을 가져와서 시간 차이만큼 회복을 시켜야 함
             _clearCount = Convert.ToInt32(etcData["stageCount"]);
+
+            if (!etcData.ContainsKey("canFaster"))
+            {
+                _firebase.SetCanFaster(false);
+                CanFaster = false;
+            }
+            else CanFaster = Convert.ToBoolean(etcData["canFaster"]);
+
+            if (!etcData.ContainsKey("canGacha"))
+            {
+                _firebase.SetCanGacha(false);
+                _canGacha = false;
+            }
+            else _canGacha = Convert.ToBoolean(etcData["canGacha"]);
         }
 
         private void SetGrowthData(IReadOnlyDictionary<string, object> growthData)

--- a/Assets/06_SDW_Folder/Scripts/UI/RogueLikeScene/RoguelikeClosingUI.cs
+++ b/Assets/06_SDW_Folder/Scripts/UI/RogueLikeScene/RoguelikeClosingUI.cs
@@ -259,13 +259,12 @@ namespace SDW
             if (fineDining != 0) _gameManager.Coin.AddRecipeItem(_gameManager.Coin.fineDining, fineDining);
             if (masterChef != 0) _gameManager.Coin.AddRecipeItem(_gameManager.Coin.masterChef, masterChef);
             _gameManager.Coin.AddPoint(point);
-
             _gameManager.InGameItem.ClearItemCounts();
             _gameManager.ClearScore();
             _gameManager.ClearStageCount();
             _battleManager.ClearCharacterHp();
             //todo QA가 아닌 버전에서는 엽전도 Clear 해야 함
-            // _gameManager.Coin.ClearYeopjeon();
+            _gameManager.Coin.ClearYeopjeon();
 
             _scorePanelButton.interactable = true;
         }

--- a/Assets/08_JJY_Folder/Scripts/Manager/CoinManager.cs
+++ b/Assets/08_JJY_Folder/Scripts/Manager/CoinManager.cs
@@ -148,7 +148,6 @@ namespace JJY
             yeopjeon += bonus;
 
             if (value >= 0) totalYeopjeon += value;
-            if (bonus >= 0) totalYeopjeon += bonus;
 
             OnYeopjeonChanged?.Invoke(yeopjeon);
             OnYeopjeonBonus?.Invoke(_yeopjeonBonus);

--- a/Assets/09_KSH_Folder/Scripts/Growths/GrowthManager.cs
+++ b/Assets/09_KSH_Folder/Scripts/Growths/GrowthManager.cs
@@ -31,7 +31,7 @@ public class GrowthManager : MonoBehaviour
         _gameManager = GameManager.Instance;
         _charData = _gameManager.CharacterData;
         if (!_hasFaster)
-            GameManager.Instance._canFaster = false;
+            GameManager.Instance.CanFaster = false;
     }
 
     private void Update()
@@ -206,8 +206,8 @@ public class GrowthManager : MonoBehaviour
             case NodeAbility.None:
                 if (growthDatas.nodeID == 80002) //배속 기능 활성화
                 {
-                    if (!GameManager.Instance._canFaster)
-                        GameManager.Instance._canFaster = true;
+                    if (!GameManager.Instance.CanFaster)
+                        GameManager.Instance.CanFaster = true;
                     // Debug.Log("배속 기능 활성화!");
                 }
                 else if (growthDatas.nodeID == 80001) //가챠 기능 활성화


### PR DESCRIPTION
* 보스 몬스터의 경우, 별도 자체 체력바가 없기에, 해당 부분 예외처리
* QA가 아니므로, 정산 시 엽전 초기화 관련 주석 제거

---

# 체크리스트
- [x] 코드가 정상적으로 빌드/실행된다
- [x] 기능이 정상 동작한다
- [x] 심각한 버그나 예상치 못한 문제는 없다