### PR TITLE
[Fix] Monster Death Animation Play Correction

### DIFF
--- a/Assets/05_KGW_Folder/Animations/Monsters/BladeMonkey/Death.anim
+++ b/Assets/05_KGW_Folder/Animations/Monsters/BladeMonkey/Death.anim
@@ -55,7 +55,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/05_KGW_Folder/Animations/Monsters/CorruptedFlower/Death.anim
+++ b/Assets/05_KGW_Folder/Animations/Monsters/CorruptedFlower/Death.anim
@@ -296,7 +296,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/05_KGW_Folder/Animations/Monsters/DustBall/Death.anim
+++ b/Assets/05_KGW_Folder/Animations/Monsters/DustBall/Death.anim
@@ -296,7 +296,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/05_KGW_Folder/Animations/Monsters/FieldMouse/Death.anim
+++ b/Assets/05_KGW_Folder/Animations/Monsters/FieldMouse/Death.anim
@@ -339,7 +339,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/05_KGW_Folder/Animations/Monsters/GhostBat/Death.anim
+++ b/Assets/05_KGW_Folder/Animations/Monsters/GhostBat/Death.anim
@@ -296,7 +296,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/05_KGW_Folder/Animations/Monsters/GiantBear/Death.anim
+++ b/Assets/05_KGW_Folder/Animations/Monsters/GiantBear/Death.anim
@@ -55,7 +55,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/05_KGW_Folder/Animations/Monsters/HerbSlime/Death.anim
+++ b/Assets/05_KGW_Folder/Animations/Monsters/HerbSlime/Death.anim
@@ -296,7 +296,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/05_KGW_Folder/Animations/Monsters/IronBull/Death.anim
+++ b/Assets/05_KGW_Folder/Animations/Monsters/IronBull/Death.anim
@@ -58,7 +58,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/05_KGW_Folder/Animations/Monsters/MistLocustSwarm/Death.anim
+++ b/Assets/05_KGW_Folder/Animations/Monsters/MistLocustSwarm/Death.anim
@@ -339,7 +339,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/05_KGW_Folder/Animations/Monsters/MountainBoar/Death.anim
+++ b/Assets/05_KGW_Folder/Animations/Monsters/MountainBoar/Death.anim
@@ -339,7 +339,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/05_KGW_Folder/Animations/Monsters/RockGolem/Death.anim
+++ b/Assets/05_KGW_Folder/Animations/Monsters/RockGolem/Death.anim
@@ -92,7 +92,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/05_KGW_Folder/Animations/Monsters/ShadowScarecrow/Death.anim
+++ b/Assets/05_KGW_Folder/Animations/Monsters/ShadowScarecrow/Death.anim
@@ -296,7 +296,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/05_KGW_Folder/Scripts/Characters/MyCharacterController.cs
+++ b/Assets/05_KGW_Folder/Scripts/Characters/MyCharacterController.cs
@@ -130,6 +130,8 @@ public class MyCharacterController : UnitBaseData
 
         _manaChangeValue = _characterState._chaMPRecovery;
 
+        Debug.Log($"공속 : {_characterState._chaEnName}{_characterState._chaAtkSpeed}");
+
         // 마나 충전 
         ManaRecovery();
     }

--- a/Assets/05_KGW_Folder/Scripts/IntegratedScripts/UnitBaseData.cs
+++ b/Assets/05_KGW_Folder/Scripts/IntegratedScripts/UnitBaseData.cs
@@ -100,11 +100,25 @@ public abstract class UnitBaseData : MonoBehaviour
         // 유닛의 사망처리
         _isAlive = false;
 
-        // 오브젝트 삭제
-        // Destroy(gameObject);
-        Invoke(nameof(MonsterDeath), 1f);
+        if (gameObject.layer == LayerMask.NameToLayer("Boss"))
+        {
+            // 매니저에 사망 보고
+            _battleManager.MonsterDeathCheck();
+        }
+        else
+        {
+            // 보스전에서는 몬스터는 사망보고 하지 않음
+            if (_battleManager._battleType == BattleEventType.Boss ||
+                _battleManager._battleType == BattleEventType.BossFinal) return;
+
+            // 매니저에 사망 보고
+            _battleManager.MonsterDeathCheck();
+        }
+
+        Invoke(nameof(MonsterDeath), 0.9f);
     }
 
+    // 몬스터 사망
     private void MonsterDeath()
     {
         gameObject.SetActive(false);

--- a/Assets/05_KGW_Folder/Scripts/Monsters/MonsterController.cs
+++ b/Assets/05_KGW_Folder/Scripts/Monsters/MonsterController.cs
@@ -22,7 +22,6 @@ public class MonsterController : UnitBaseData
     // 몬스터의 상태
     public MonsterState _monsterState;
 
-    public bool _isDetect;
     public bool _isFirst;
     public bool _isApplyPassive;
     private bool _isFirstAttack;
@@ -391,6 +390,7 @@ public class MonsterController : UnitBaseData
             _breakCount = 0f;
             _battleManager.ReportBreakGauge(_breakCount, _monsterState._monbreakGage);
             _monAnimatior.Play(Death_Hash);
+
             // 유닛의 죽음
             Death();
         }
@@ -451,24 +451,9 @@ public class MonsterController : UnitBaseData
     // 몬스터 사망
     protected override void Death()
     {
-        base.Death();
         OnRelicMonsterDeath?.Invoke();
-        if (gameObject.layer == LayerMask.NameToLayer("Boss"))
-        {
-            _isDetect = false;
 
-            // 매니저에 사망 보고
-            _battleManager.MonsterDeathCheck();
-        }
-        else
-        {
-            // 보스전에서는 몬스터는 사망보고 하지 않음
-            if (_battleManager._battleType == BattleEventType.Boss ||
-                _battleManager._battleType == BattleEventType.BossFinal) return;
-
-            // 매니저에 사망 보고
-            _battleManager.MonsterDeathCheck();
-        }
+        base.Death();
     }
 
     // 공격 대상 변경

--- a/Assets/05_KGW_Folder/Scripts/Monsters/MonsterResearchContoller.cs
+++ b/Assets/05_KGW_Folder/Scripts/Monsters/MonsterResearchContoller.cs
@@ -13,9 +13,6 @@ public class MonsterResearchContoller : MonoBehaviour
             // 적이 감지되고 보스몬스터이면 스킬 사용
             if (_controller.gameObject.layer == LayerMask.NameToLayer("Boss"))
             {
-                // 적 감지
-                _controller._isDetect = true;
-
                 if (!_controller._isFirst)
                 {
                     _controller.UseRecallSkill();

--- a/Assets/05_KGW_Folder/Scripts/UI/ClearChapterUI/ClearStageUI.cs
+++ b/Assets/05_KGW_Folder/Scripts/UI/ClearChapterUI/ClearStageUI.cs
@@ -66,6 +66,7 @@ namespace SDW
                 content.gameObject.SetActive(false);
                 GameManager.Instance.Coin.AddYeopjeon(getYeopjeon);
                 UpdateYeopjeonText(GameManager.Instance.Coin.bonus);
+                MapView.Instance._eventManager.SetCombatReward(false, 0);
             }
             else
             {


### PR DESCRIPTION
몬스터 사망 시 애니메이션 중복 플레이어 루프 해제

< 체크 리스트 >
- [x]  코드가 정상적으로 빌드/실행된다
- [x]  기능이 정상 동작한다
- [x] 심각한 버그나 예상치 못한 문제는 없다